### PR TITLE
Parse `repo_type` from fsspec url + some minor fixes/tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Check quality
         run: |
           black --check tests src
-          isort --check-only tests src
-          flake8 tests src
+          ruff tests src
 
   test:
     needs: check_code_quality

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Ruff
+.ruff_cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ If you would like to work on any of the open Issues:
 
 5. Develop the features on your branch. 
 
-6. Format your code. Run black and isort so that your newly added files look nice with the following command:
+6. Format your code. Run black and ruff so that your newly added files look nice with the following command:
 
 	```bash
 	make style

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,13 @@ check_dirs := tests src setup.py
 
 quality:
 	black --check $(check_dirs)
-	isort --check-only $(check_dirs)
-	flake8 $(check_dirs)
+	ruff $(check_dirs)
 
 # Format source code automatically
 
 style:
 	black $(check_dirs)
-	isort $(check_dirs)
+	ruff $(check_dirs) --fix
 
 # Run tests for the library
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Instantiation via `fsspec`:
 ['.gitattributes', 'config.json', 'pytorch_model.bin']
 
 >>> # Instantiate a `hffs.HfFileSystem` object and write a file to it
->>> with fsspec.open("hf://dataset/my-username/my-dataset-repo:/my-file-new.txt"):
+>>> with fsspec.open("hf://datasets/my-username/my-dataset-repo:/my-file-new.txt"):
 ...     f.write("Hello, world1")
 ...     f.write("Hello, world2")
 ```
@@ -63,10 +63,10 @@ pip install hffs
 >>> import pandas as pd
 
 >>> # Read a remote CSV file into a dataframe
->>> df = pd.read_csv("hf://dataset/my-username/my-dataset-repo:/train.csv")
+>>> df = pd.read_csv("hf://datasets/my-username/my-dataset-repo:/train.csv")
 
 >>> # Write a dataframe to a remote CSV file
->>> df.to_csv("hf://dataset/my-username/my-dataset-repo:/test.csv")
+>>> df.to_csv("hf://datasets/my-username/my-dataset-repo:/test.csv")
 ```
 
 * [`datasets`](https://huggingface.co/docs/datasets/filesystems#load-and-save-your-datasets-using-your-cloud-storage-filesystem)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Instantiation via `fsspec`:
 >>> import fsspec
 
 >>> # Instantiate a `hffs.HfFileSystem` object
->>> fs = fsspec.filesystem("hf://model/my-username/my-model-repo")
+>>> fs = fsspec.filesystem("hf://my-username/my-model-repo")
 >>> fs.ls("")
 ['.gitattributes', 'config.json', 'pytorch_model.bin']
 

--- a/README.md
+++ b/README.md
@@ -105,17 +105,14 @@ pip install hffs
 ...    first_row = root["embeddings/experiment_0"][0]
 ```
 
-* [`pyarrow`] + [`duckdb`]
+* [`duckdb`](https://duckdb.org/docs/guides/python/filesystems)
 
 ```python
 >>> import hffs
->>> import pyarrow.dataset as ds
 >>> import duckdb
 
 >>> fs = hffs.HfFileSystem("my-username/my-dataset-repo", repo_type="dataset")
-
->>> # Query a remote dataset and get the result as a dataframe
->>> dset = ds.dataset("data/", filesystem=fs)
->>> con = duckdb.connect()
->>> df = con.execute("SELECT * FROM dset LIMIT 1-").df()
+>>> duckdb.register_filesystem(fs)
+>>> # Query a remote file and get the result as a dataframe
+>>> df = duckdb.query("SELECT * FROM 'hf://data.parquet' LIMIT 10").df()
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ pip install hffs
 >>> import datasets
 
 >>> # Export a (large) dataset to a repo
->>> cache_dir = "hf://dataset/my-username/my-dataset-repo"
+>>> cache_dir = "hf://datasets/my-username/my-dataset-repo"
 >>> builder = datasets.load_dataset_builder("path/to/local/loading_script/loading_script.py", cache_dir=cache_dir)
 >>> builder.download_and_prepare(file_format="parquet")
 
@@ -95,13 +95,13 @@ pip install hffs
 >>> embeddings = np.random.randn(50000, 1000).astype("float32")
 
 >>> # Write an array to a repo acting as a remote zarr store
->>> with zarr.open_group("hf://model/my-username/my-model-repo:/array-store", mode="w") as root:
+>>> with zarr.open_group("hf://my-username/my-model-repo:/array-store", mode="w") as root:
 ...    foo = root.create_group("embeddings")
 ...    foobar = foo.zeros('experiment_0', shape=(50000, 1000), chunks=(10000, 1000), dtype='f4')
 ...    foobar[:] = embeddings
 
 >>> # Read from a remote zarr store
->>> with zarr.open_group("hf://model/my-username/my-model-repo:/array-store", mode="r") as root:
+>>> with zarr.open_group("hf://my-username/my-model-repo:/array-store", mode="r") as root:
 ...    first_row = root["embeddings/experiment_0"][0]
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,15 @@
 line-length = 119
 target_version = ['py37', 'py38', 'py39', 'py310']
 preview = true
+
+[tool.ruff]
+# Ignored rules:
+#   "E501" -> line length violation
+#   "F821" -> undefined named in type annotation (e.g. Literal["something"])
+ignore = ["E501", "F821"]
+select = ["E", "F", "I", "W"]
+line-length = 119
+
+[tool.ruff.isort]
+lines-after-imports = 2
+known-first-party = ["hffs"]

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ from setuptools import find_packages, setup
 REQUIRED_PKGS = [
     "fsspec",
     "requests",
-    "huggingface_hub>=0.10.0",
+    "huggingface_hub>=0.12.0",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,50 +8,92 @@ Note:
 
 Simple check list for release from AllenNLP repo: https://github.com/allenai/allennlp/blob/master/setup.py
 
-To create the package for pypi.
+Steps to make a release:
 
 0. Prerequisites:
    - Dependencies:
-     - twine: "pip install twine"
-   - Create an account in (and join the 'datasets' project):
+     - twine: `pip install twine`
+   - Create an account in (and join the 'hffs' project):
      - PyPI: https://pypi.org/
      - Test PyPI: https://test.pypi.org/
 
-1. Change the version in:
+1. Create the release branch from main branch:
+     ```
+     git checkout main
+     git pull upstream main
+     git checkout -b release-VERSION
+     ```
+2. Change the version to the release VERSION in:
    - __init__.py
    - setup.py
 
-2. Commit these changes: "git commit -m 'Release: VERSION'"
+3. Commit these changes, push and create a Pull Request:
+     ```
+     git add -u
+     git commit -m "Release: VERSION"
+     git push upstream release-VERSION
+     ```
+   - Go to: https://github.com/huggingface/hffs/pull/new/release
+   - Create pull request
 
-3. Add a tag in git to mark the release: "git tag VERSION -m 'Add tag VERSION for pypi'"
-   Push the tag to remote: git push --tags origin main
-
-4. Build both the sources and the wheel. Do not change anything in setup.py between
+4. From your local release branch, build both the sources and the wheel. Do not change anything in setup.py between
    creating the wheel and the source distribution (obviously).
+   - First, delete any building directories that may exist from previous builds:
+     - build
+     - dist
+   - From the top level directory, build the wheel and the sources:
+       ```
+       python setup.py bdist_wheel
+       python setup.py sdist
+       ```
+   - You should now have a /dist directory with both .whl and .tar.gz source versions.
 
-   First, delete any "build" directory that may exist from previous builds.
-
-   For the wheel, run: "python setup.py bdist_wheel" in the top level directory.
-   (this will build a wheel for the python version you use to build it).
-
-   For the sources, run: "python setup.py sdist"
-   You should now have a /dist directory with both .whl and .tar.gz source versions.
-
-5. Check that everything looks correct by uploading the package to the pypi test server:
-
-   twine upload dist/* -r pypitest --repository-url=https://test.pypi.org/legacy/
-
+5. Check that everything looks correct by uploading the package to the test PyPI server:
+     ```
+     twine upload dist/* -r pypitest --repository-url=https://test.pypi.org/legacy/
+     ```
    Check that you can install it in a virtualenv/notebook by running:
-   pip install huggingface_hub fsspec aiohttp
-   pip install -i https://testpypi.python.org/pypi hffs
+     ```
+     pip install huggingface_hub fsspec aiohttp
+     pip install -U tqdm
+     pip install -i https://testpypi.python.org/pypi hffs
+     ```
 
-6. Upload the final version to actual pypi:
-   twine upload dist/* -r pypi
+6. Upload the final version to the actual PyPI:
+     ```
+     twine upload dist/* -r pypi
+     ```
 
-7. Fill release notes in the tag in github once everything is looking hunky-dory.
+7. Make the release on GitHub once everything is looking hunky-dory:
+   - Merge the release Pull Request
+   - Create a new release: https://github.com/huggingface/hffs/releases/new
+   - Choose a tag: Introduce the new VERSION as tag, that will be created when you publish the release
+     - Create new tag VERSION on publish
+   - Release title: Introduce the new VERSION as well
+   - Describe the release
+     - Use "Generate release notes" button for automatic generation
+   - Publish release
 
-8. Change the version in __init__.py and setup.py to X.X.X+1.dev0 (e.g. VERSION=1.18.3 -> 1.18.4.dev0).
-   Then push the change with a message 'set dev version'
+8. Set the dev version
+   - Create the dev-version branch from the main branch:
+       ```
+       git checkout main
+       git pull upstream main
+       git branch -D dev-version
+       git checkout -b dev-version
+       ```
+   - Change the version to X.X.X+1.dev0 (e.g. VERSION=1.18.3 -> 1.18.4.dev0) in:
+     - __init__.py
+     - setup.py
+   - Commit these changes, push and create a Pull Request:
+       ```
+       git add -u
+       git commit -m "Set dev version"
+       git push upstream dev-version
+       ```
+     - Go to: https://github.com/huggingface/hffs/pull/new/dev-version
+     - Create pull request
+   - Merge the dev version Pull Request
 """
 
 
@@ -59,10 +101,8 @@ from setuptools import find_packages, setup
 
 
 REQUIRED_PKGS = [
-    # minimum 2021.11.1 so that BlockSizeError is fixed: see https://github.com/fsspec/filesystem_spec/pull/830
     "fsspec",
     "requests",
-    # To use the HfApi to get the files info from huggingface.co
     "huggingface_hub>=0.10.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,6 @@ setup(
     license="Apache 2.0",
     package_dir={"": "src"},
     packages=find_packages("src"),
-    package_data={"hffs": ["py.typed"]},
     python_requires=">=3.7.0",
     install_requires=REQUIRED_PKGS,
     extras_require=EXTRAS_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ REQUIRED_PKGS = [
     "fsspec",
     "requests",
     "huggingface_hub>=0.12.0",
+    "packaging>=20.9",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ TESTS_REQUIRE = [
 ]
 
 
-QUALITY_REQUIRE = ["black~=22.0", "flake8>=3.8.3", "isort>=5.0.0"]
+QUALITY_REQUIRE = ["black~=23.1", "ruff>=0.0.241"]
 
 
 EXTRAS_REQUIRE = {

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -333,7 +333,7 @@ class HfFile(fsspec.spec.AbstractBufferedFile):
         return r.content
 
     def _initiate_upload(self):
-        self.temp_file = tempfile.NamedTemporaryFile(dir=huggingface_hub.constants.HUGGINGFACE_HUB_CACHE, delete=False)
+        self.temp_file = tempfile.NamedTemporaryFile(delete=False)
 
     def _upload_chunk(self, final=False):
         self.buffer.seek(0)

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -355,7 +355,3 @@ class HfFile(fsspec.spec.AbstractBufferedFile):
             os.remove(self.temp_file.name)
             self.fs.invalidate_cache()
 
-
-# parquet issue by severo
-# token
-# docs

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -1,8 +1,9 @@
 import collections
 import os
+import re
 import tempfile
 from pathlib import PurePosixPath
-from typing import Optional, Tuple
+from typing import Optional
 from urllib.parse import quote
 
 import fsspec
@@ -11,42 +12,7 @@ import huggingface_hub.constants
 import huggingface_hub.utils
 import requests
 
-
-def _repo_type_and_id_from_hf_id(hf_id: str) -> Tuple[Optional[str], Optional[str], str]:
-    """
-    Returns the repo type and ID from a HF ID
-    Args:
-        hf_id (`str`):
-            An URL or ID of a repository on the HF hub. Accepted values are:
-            - <repo_type>/<namespace>/<repo_id>
-            - <namespace>/<repo_id>
-            - <repo_id>
-    Returns:
-        A tuple with two items: repo_type (`str` or `None`), namespace (`str` or
-        `None`) and repo_id (`str`).
-    """
-    url_segments = hf_id.split("/")
-    is_hf_id = len(url_segments) <= 3
-    if is_hf_id:
-        if len(url_segments) == 3:
-            # Passed <repo_type>/<user>/<model_id> or <repo_type>/<org>/<model_id>
-            repo_type, namespace, repo_id = url_segments[-3:]
-        elif len(url_segments) == 2:
-            # Passed <user>/<model_id> or <org>/<model_id>
-            namespace, repo_id = hf_id.split("/")[-2:]
-            repo_type = None
-        else:
-            # Passed <model_id>
-            repo_id = url_segments[0]
-            namespace, repo_type = None, None
-    else:
-        raise ValueError(f"Unable to retrieve user and repo ID from the passed HF ID: {hf_id}")
-
-    if repo_type not in huggingface_hub.constants.REPO_TYPES:
-        assert repo_type is not None, "repo_type `None` do not have mapping"
-        repo_type = huggingface_hub.constants.REPO_TYPES_MAPPING.get(repo_type)
-
-    return repo_type, namespace, repo_id
+from . import __version__
 
 
 # huggingface_hub.hf_hub_url doesn't support non-default endpoints at the moment
@@ -148,7 +114,9 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         self.token = token if token is not None else huggingface_hub.HfFolder.get_token()
         self.repo_type = repo_type if repo_type is not None else huggingface_hub.constants.REPO_TYPE_MODEL
         self.revision = revision
-        self._api = huggingface_hub.HfApi(endpoint=endpoint, token=token)
+        self._api = huggingface_hub.HfApi(
+            endpoint=endpoint, token=token, library_name="hffs", library_version=__version__
+        )
 
     def _dircache_from_repo_info(self):
         repo_info = self._api.repo_info(
@@ -204,14 +172,21 @@ class HfFileSystem(fsspec.AbstractFileSystem):
             path = path[len(protocol + "://") :]
         hf_id, *paths = path.split(":/", 1)
         hf_id, *revisions = hf_id.split("@", 1)
+        parsed_id = huggingface_hub.RepoUrl(hf_id)
+
         out = {}
-        repo_type, namespace, repo_id = _repo_type_and_id_from_hf_id(hf_id)
-        repo_id = f"{namespace}/{repo_id}" if namespace is not None else repo_id
-        out["repo_id"] = repo_id
-        if repo_type is not None:
-            out["repo_type"] = repo_type
+        out["repo_id"] = parsed_id.repo_id
+        out["repo_type"] = parsed_id.repo_type
         if revisions:
             out["revision"] = revisions[0]
+
+        # Corner case: canonical datasets URLs are not parsed correctly by `huggingface_hub`
+        # TODO: remove this once https://github.com/huggingface/huggingface_hub/issues/1336 is fixed.
+        if out["repo_type"] == "model":
+            match = re.match(r"datasets?/(?P<repo_id>.*)", out["repo_id"])
+            if match is not None:
+                out["repo_type"], out["repo_id"] = "dataset", match.groupdict()["repo_id"]
+
         return out
 
     def _open(
@@ -276,7 +251,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
 
         # TODO: Wait for https://github.com/huggingface/huggingface_hub/issues/1083 to be resolved to simplify this logic
         if self.info(path1)["lfs"] is not None:
-            headers = huggingface_hub.utils.build_hf_headers(token=self.token, is_write_action=True)
+            headers = self._api._build_hf_headers(is_write_action=True)
             commit_message = f"Copy {path1} to {path2}"
             payload = {
                 "summary": kwargs.get("commit_message", commit_message),
@@ -319,7 +294,7 @@ class HfFile(fsspec.spec.AbstractBufferedFile):
     def _fetch_range(self, start, end):
         headers = {
             "range": f"bytes={start}-{end}",
-            **huggingface_hub.utils.build_hf_headers(token=self.fs.token),
+            **self.fs._api._build_hf_headers(),
         }
         url = _path_to_http_url(
             self.path,

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -303,11 +303,12 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         path = self._strip_protocol(path)
         if not self.isfile(path):
             raise FileNotFoundError(path)
+        headers = self._api._build_hf_headers()
         revision = self.revision if self.revision is not None else huggingface_hub.constants.DEFAULT_REVISION
         r = requests.get(
             f"{self.endpoint}/api/{self.repo_type}s/{self.repo_id}/tree/{quote(revision, safe='')}/{quote(self._parent(path), safe='')}"
             .rstrip("/"),
-            headers=huggingface_hub.utils.build_hf_headers(token=self.token),
+            headers=headers,
         )
         huggingface_hub.utils.hf_raise_for_status(r)
         modified_date = None

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -235,8 +235,8 @@ class HfFileSystem(fsspec.AbstractFileSystem):
             token=self.token,
             operations=operations,
             revision=self.revision,
-            commit_message=kwargs.pop("commit_message", commit_message),
-            commit_description=kwargs.pop("commit_description", None),
+            commit_message=kwargs.get("commit_message", commit_message),
+            commit_description=kwargs.get("commit_description", None),
         )
         self.invalidate_cache()
 
@@ -254,8 +254,8 @@ class HfFileSystem(fsspec.AbstractFileSystem):
             token=self.token,
             operations=operations,
             revision=self.revision,
-            commit_message=kwargs.pop("commit_message", commit_message),
-            commit_description=kwargs.pop("commit_description", None),
+            commit_message=kwargs.get("commit_message", commit_message),
+            commit_description=kwargs.get("commit_description", None),
         )
         self.invalidate_cache()
 
@@ -279,8 +279,8 @@ class HfFileSystem(fsspec.AbstractFileSystem):
             headers = huggingface_hub.utils.build_hf_headers(token=self.token, is_write_action=True)
             commit_message = f"Copy {path1} to {path2}"
             payload = {
-                "summary": kwargs.pop("commit_message", commit_message),
-                "description": kwargs.pop("commit_description", ""),
+                "summary": kwargs.get("commit_message", commit_message),
+                "description": kwargs.get("commit_description", ""),
                 "files": [],
                 "lfsFiles": [
                     {
@@ -309,8 +309,8 @@ class HfFileSystem(fsspec.AbstractFileSystem):
                 token=self.token,
                 repo_type=self.repo_type,
                 revision=self.revision,
-                commit_message=kwargs.pop("commit_message", commit_message),
-                commit_description=kwargs.pop("commit_description", None),
+                commit_message=kwargs.get("commit_message", commit_message),
+                commit_description=kwargs.get("commit_description"),
             )
         self.invalidate_cache()
 
@@ -349,8 +349,8 @@ class HfFile(fsspec.spec.AbstractBufferedFile):
                 token=self.fs.token,
                 repo_type=self.fs.repo_type,
                 revision=self.fs.revision,
-                commit_message=self.kwargs.pop("commit_message", commit_message),
-                commit_description=self.kwargs.pop("commit_description", None),
+                commit_message=self.kwargs.get("commit_message", commit_message),
+                commit_description=self.kwargs.get("commit_description"),
             )
             os.remove(self.temp_file.name)
             self.fs.invalidate_cache()

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -333,7 +333,7 @@ class HfFile(fsspec.spec.AbstractBufferedFile):
         return r.content
 
     def _initiate_upload(self):
-        self.temp_file = tempfile.NamedTemporaryFile(delete=False)
+        self.temp_file = tempfile.NamedTemporaryFile(prefix="hffs-", delete=False)
 
     def _upload_chunk(self, final=False):
         self.buffer.seek(0)

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -2,7 +2,7 @@ import collections
 import os
 import tempfile
 from pathlib import PurePosixPath
-from typing import Dict, Optional, Tuple
+from typing import Optional, Tuple
 from urllib.parse import quote
 
 import fsspec
@@ -354,4 +354,3 @@ class HfFile(fsspec.spec.AbstractBufferedFile):
             )
             os.remove(self.temp_file.name)
             self.fs.invalidate_cache()
-

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -2,7 +2,7 @@ import collections
 import os
 import tempfile
 from pathlib import PurePosixPath
-from typing import Optional
+from typing import Dict, Optional, Tuple
 from urllib.parse import quote
 
 import fsspec
@@ -11,7 +11,42 @@ import huggingface_hub.constants
 import huggingface_hub.utils
 import requests
 
-from . import __version__
+
+def _repo_type_and_id_from_hf_id(hf_id: str) -> Tuple[Optional[str], Optional[str], str]:
+    """
+    Returns the repo type and ID from a HF ID
+    Args:
+        hf_id (`str`):
+            An URL or ID of a repository on the HF hub. Accepted values are:
+            - <repo_type>/<namespace>/<repo_id>
+            - <namespace>/<repo_id>
+            - <repo_id>
+    Returns:
+        A tuple with two items: repo_type (`str` or `None`), namespace (`str` or
+        `None`) and repo_id (`str`).
+    """
+    url_segments = hf_id.split("/")
+    is_hf_id = len(url_segments) <= 3
+    if is_hf_id:
+        if len(url_segments) == 3:
+            # Passed <repo_type>/<user>/<model_id> or <repo_type>/<org>/<model_id>
+            repo_type, namespace, repo_id = url_segments[-3:]
+        elif len(url_segments) == 2:
+            # Passed <user>/<model_id> or <org>/<model_id>
+            namespace, repo_id = hf_id.split("/")[-2:]
+            repo_type = None
+        else:
+            # Passed <model_id>
+            repo_id = url_segments[0]
+            namespace, repo_type = None, None
+    else:
+        raise ValueError(f"Unable to retrieve user and repo ID from the passed HF ID: {hf_id}")
+
+    if repo_type not in huggingface_hub.constants.REPO_TYPES:
+        assert repo_type is not None, "repo_type `None` do not have mapping"
+        repo_type = huggingface_hub.constants.REPO_TYPES_MAPPING.get(repo_type)
+
+    return repo_type, namespace, repo_id
 
 
 # huggingface_hub.hf_hub_url doesn't support non-default endpoints at the moment
@@ -81,11 +116,11 @@ class HfFileSystem(fsspec.AbstractFileSystem):
     >>> import fsspec
 
     >>> # Read a remote file
-    >>> with fsspec.open("hf://username/my-dataset:/remote/file/in/repo.bin", repo_type="dataset") as f:
+    >>> with fsspec.open("hf://dataset/my-username/my-dataset:/remote/file/in/repo.bin") as f:
     ...     data = f.read()
 
     >>> # Write a remote file
-    >>> with fsspec.open("hf://username/my-dataset:/remote/file/in/repo.bin", "wb", repo_type="dataset") as f:
+    >>> with fsspec.open("hf://dataset/my-username/my-dataset:/remote/file/in/repo.bin", "wb") as f:
     ...     f.write(data)
     ```
     """
@@ -97,10 +132,10 @@ class HfFileSystem(fsspec.AbstractFileSystem):
     def __init__(
         self,
         repo_id: str,
-        endpoint: Optional[str] = None,
         token: Optional[str] = None,
         repo_type: Optional[str] = None,
         revision: Optional[str] = None,
+        endpoint: Optional[str] = None,
         **kwargs,
     ):
         super().__init__(self, **kwargs)
@@ -113,7 +148,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         self.token = token if token is not None else huggingface_hub.HfFolder.get_token()
         self.repo_type = repo_type if repo_type is not None else huggingface_hub.constants.REPO_TYPE_MODEL
         self.revision = revision
-        self._api = huggingface_hub.HfApi(endpoint=endpoint)
+        self._api = huggingface_hub.HfApi(endpoint=endpoint, token=token)
 
     def _dircache_from_repo_info(self):
         repo_info = self._api.repo_info(
@@ -153,13 +188,13 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         protocol = cls.protocol
         if path.startswith(protocol + "://"):
             path = path[len(protocol + "://") :]
-            repo_id, *paths = path.split(":/", 1)
+            hf_id, *paths = path.split(":/", 1)
             path = paths[0] if paths else cls.root_marker
         return path
 
     def unstrip_protocol(self, path):
         return super().unstrip_protocol(
-            self.repo_id + ("@" + self.revision if self.revision is not None else "") + ":/" + path
+            f"{self.repo_type}/{self.repo_id}{'@' + self.revision if self.revision is not None else ''}:/{path}"
         )
 
     @staticmethod
@@ -167,10 +202,14 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         protocol = HfFileSystem.protocol
         if path.startswith(protocol + "://"):
             path = path[len(protocol + "://") :]
-        repo_id, *paths = path.split(":/", 1)
-        repo_id, *revisions = repo_id.split("@", 1)
+        hf_id, *paths = path.split(":/", 1)
+        hf_id, *revisions = hf_id.split("@", 1)
         out = {}
+        repo_type, namespace, repo_id = _repo_type_and_id_from_hf_id(hf_id)
+        repo_id = f"{namespace}/{repo_id}" if namespace is not None else repo_id
         out["repo_id"] = repo_id
+        if repo_type is not None:
+            out["repo_type"] = repo_type
         if revisions:
             out["revision"] = revisions[0]
         return out
@@ -182,32 +221,32 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         **kwargs,
     ):
         if mode == "ab":
-            raise NotImplementedError("Appending to remote files is not supported")
+            raise NotImplementedError("Appending to remote files is not yet supported.")
         path = self._strip_protocol(path)
         return HfFile(self, path, mode=mode, **kwargs)
 
-    def _rm(self, path):
+    def _rm(self, path, **kwargs):
         path = self._strip_protocol(path)
         operations = [huggingface_hub.CommitOperationDelete(path_in_repo=path)]
-        commit_message = f"Delete {path} with hffs"
+        commit_message = f"Delete {path}"
         self._api.create_commit(
             repo_id=self.repo_id,
             repo_type=self.repo_type,
             token=self.token,
             operations=operations,
             revision=self.revision,
-            commit_message=commit_message,
+            commit_message=kwargs.pop("commit_message", commit_message),
+            commit_description=kwargs.pop("commit_description", None),
         )
         self.invalidate_cache()
 
-    def rm(self, path, recursive=False, maxdepth=None):
+    def rm(self, path, recursive=False, maxdepth=None, **kwargs):
         paths = self.expand_path(path, recursive=recursive, maxdepth=maxdepth)
         file_paths = [path for path in paths if not self.isdir(path)]
         operations = [huggingface_hub.CommitOperationDelete(path_in_repo=file_path) for file_path in file_paths]
         commit_message = f"Delete {path} "
         commit_message += "recursively " if recursive else ""
         commit_message += f"up to depth {maxdepth} " if maxdepth is not None else ""
-        commit_message += "with hffs"
         # TODO: use `commit_description` to list all the deleted paths?
         self._api.create_commit(
             repo_id=self.repo_id,
@@ -215,7 +254,8 @@ class HfFileSystem(fsspec.AbstractFileSystem):
             token=self.token,
             operations=operations,
             revision=self.revision,
-            commit_message=commit_message,
+            commit_message=kwargs.pop("commit_message", commit_message),
+            commit_description=kwargs.pop("commit_description", None),
         )
         self.invalidate_cache()
 
@@ -234,14 +274,13 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         path1 = self._strip_protocol(path1)
         path2 = self._strip_protocol(path2)
 
+        # TODO: Wait for https://github.com/huggingface/huggingface_hub/issues/1083 to be resolved to simplify this logic
         if self.info(path1)["lfs"] is not None:
-            # Perhaps we can add a CopyOperation to the commit API in huggingace_hub?
-            headers = huggingface_hub.utils.build_hf_headers(
-                use_auth_token=self.token, library_name="hffs", library_version=__version__
-            )
+            headers = huggingface_hub.utils.build_hf_headers(token=self.token, is_write_action=True)
+            commit_message = f"Copy {path1} to {path2}"
             payload = {
-                "summary": f"Copy {path1} to {path2} with hffs",
-                "description": "",
+                "summary": kwargs.pop("commit_message", commit_message),
+                "description": kwargs.pop("commit_description", ""),
                 "files": [],
                 "lfsFiles": [
                     {
@@ -254,7 +293,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
             }
             revision = self.revision if self.revision is not None else huggingface_hub.constants.DEFAULT_REVISION
             r = requests.post(
-                f"{self.endpoint}/api/{self.repo_type}s/{self.repo_id}/commit/{revision}",
+                f"{self.endpoint}/api/{self.repo_type}s/{self.repo_id}/commit/{quote(revision, safe='')}",
                 json=payload,
                 headers=headers,
             )
@@ -262,6 +301,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         else:
             with self.open(path1, "rb") as f:
                 content = f.read()
+            commit_message = f"Copy {path1} to {path2}"
             self._api.upload_file(
                 path_or_fileobj=content,
                 path_in_repo=path2,
@@ -269,7 +309,8 @@ class HfFileSystem(fsspec.AbstractFileSystem):
                 token=self.token,
                 repo_type=self.repo_type,
                 revision=self.revision,
-                commit_message=f"Copy {path1} to {path2} with hffs",
+                commit_message=kwargs.pop("commit_message", commit_message),
+                commit_description=kwargs.pop("commit_description", None),
             )
         self.invalidate_cache()
 
@@ -278,9 +319,7 @@ class HfFile(fsspec.spec.AbstractBufferedFile):
     def _fetch_range(self, start, end):
         headers = {
             "range": f"bytes={start}-{end}",
-            **huggingface_hub.utils.build_hf_headers(
-                use_auth_token=self.fs.token, library_name="hffs", library_version=__version__
-            ),
+            **huggingface_hub.utils.build_hf_headers(token=self.fs.token),
         }
         url = _path_to_http_url(
             self.path,
@@ -294,25 +333,15 @@ class HfFile(fsspec.spec.AbstractBufferedFile):
         return r.content
 
     def _initiate_upload(self):
-        self.temp_file = tempfile.NamedTemporaryFile(delete=False)
+        self.temp_file = tempfile.NamedTemporaryFile(dir=huggingface_hub.constants.HUGGINGFACE_HUB_CACHE, delete=False)
 
     def _upload_chunk(self, final=False):
         self.buffer.seek(0)
         block = self.buffer.read()
-        # if final and len(block) == self.loc:
-        #     # delegate first flush to `upload_file` if possible
-        #     self.fs._api.upload_file(
-        #         path_or_fileobj=self.temp_file.name,
-        #         path_in_repo=self.path,
-        #         repo_id=self.fs.repo_id,
-        #         token=self.fs.token,
-        #         repo_type=self.fs.repo_type,
-        #         revision=self.fs.revision,
-        #         commit_message=f"Upload {self.path} with hffs",
-        #     )
         self.temp_file.write(block)
         if final:
             self.temp_file.close()
+            commit_message = f"Upload {self.path}"
             self.fs._api.upload_file(
                 path_or_fileobj=self.temp_file.name,
                 path_in_repo=self.path,
@@ -320,7 +349,13 @@ class HfFile(fsspec.spec.AbstractBufferedFile):
                 token=self.fs.token,
                 repo_type=self.fs.repo_type,
                 revision=self.fs.revision,
-                commit_message=f"Upload {self.path} with hffs",
+                commit_message=self.kwargs.pop("commit_message", commit_message),
+                commit_description=self.kwargs.pop("commit_description", None),
             )
             os.remove(self.temp_file.name)
             self.fs.invalidate_cache()
+
+
+# parquet issue by severo
+# token
+# docs

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,7 +1,9 @@
 import time
 import unittest
+from typing import Dict
 
 import fsspec
+import pytest
 from fsspec.spec import AbstractBufferedFile
 from huggingface_hub import HfApi
 
@@ -147,3 +149,30 @@ class HfFileSystemTests(unittest.TestCase):
         fs, _, _ = fsspec.get_fs_token_paths(f"hf://{self.repo_id}:/data/text_data.txt")
         self.assertEqual(fs.repo_id, self.repo_id)
         self.assertEqual(fs.repo_type, "model")
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        # Repo type "model" by default
+        ("gpt2", {"repo_id": "gpt2", "repo_type": "model"}),
+        ("hf://gpt2", {"repo_id": "gpt2", "repo_type": "model"}),
+        # Parse without protocol
+        ("datasets/username/my_dataset", {"repo_id": "username/my_dataset", "repo_type": "dataset"}),
+        # Parse with hf:// protocol
+        ("hf://datasets/username/my_dataset", {"repo_id": "username/my_dataset", "repo_type": "dataset"}),
+        # Parse with revision
+        (
+            "hf://datasets/username/my_dataset@0123456789",
+            {"repo_id": "username/my_dataset", "repo_type": "dataset", "revision": "0123456789"},
+        ),
+        # Parse canonical models (no namespace)
+        ("gpt2", {"repo_id": "gpt2", "repo_type": "model"}),
+        ("hf://gpt2", {"repo_id": "gpt2", "repo_type": "model"}),
+        # Canonical datasets are not parsed correctly by huggingface_hub yet. They are processed separately by hffs.
+        ("datasets/squad", {"repo_id": "squad", "repo_type": "dataset"}),
+        ("hf://datasets/squad", {"repo_id": "squad", "repo_type": "dataset"}),
+    ],
+)
+def test_parse_hffs_path_success(path: str, expected: Dict[str, str]) -> None:
+    assert HfFileSystem._get_kwargs_from_urls(path) == expected

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,3 +1,4 @@
+import datetime
 import time
 import unittest
 from typing import Dict
@@ -128,6 +129,16 @@ class HfFileSystemTests(unittest.TestCase):
         with hffs.open("data/binary_data_copy.bin", "rb") as f:
             self.assertEqual(f.read(), b"dummy binary data")
         self.assertIsNotNone(hffs.info("data/binary_data_copy.bin")["lfs"])
+
+    def test_modified_time(self):
+        hffs = HfFileSystem(self.repo_id, endpoint=self._endpoint, token=self._token, repo_type=self.repo_type)
+        self.assertIsInstance(hffs.modified("data/text_data.txt"), datetime.datetime)
+        # should fail on a non-existing file/directory
+        with self.assertRaises(FileNotFoundError):
+            hffs.modified("data/not_existing_file.txt")
+        # should fail on a directory
+        with self.assertRaises(FileNotFoundError):
+            hffs.modified("data")
 
     def test_initialize_from_fsspec(self):
         fs, _, paths = fsspec.get_fs_token_paths(

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -129,11 +129,10 @@ class HfFileSystemTests(unittest.TestCase):
 
     def test_initialize_from_fsspec(self):
         fs, _, paths = fsspec.get_fs_token_paths(
-            f"hf://{self.repo_id}:/data/text_data.txt",
+            f"hf://{self.repo_type}/{self.repo_id}:/data/text_data.txt",
             storage_options={
                 "endpoint": self._endpoint,
                 "token": self._token,
-                "repo_type": self.repo_type,
                 "revision": "test-branch",
             },
         )
@@ -144,3 +143,7 @@ class HfFileSystemTests(unittest.TestCase):
         self.assertEqual(fs.repo_type, self.repo_type)
         self.assertEqual(fs.revision, "test-branch")
         self.assertEqual(paths, ["data/text_data.txt"])
+
+        fs, _, _ = fsspec.get_fs_token_paths(f"hf://{self.repo_id}:/data/text_data.txt")
+        self.assertEqual(fs.repo_id, self.repo_id)
+        self.assertEqual(fs.repo_type, "model")


### PR DESCRIPTION
This PR contains some finishing touches for the release:
* fixes https://github.com/huggingface/hffs/issues/8 (`repo_type` is not suffixed by "s" for consistency with `hfh`'s `RepoUrl`)
* fixes a bug reported by @severo ([internal link](https://www.notion.so/huggingface2/hffs-94b8e11287da4eeab605af2377a26aa0)) - fixed by quoting the revision param in `cp_file` for the LFS file case
* the default commit messages can now be modified using `kwargs`
* minor improvements in the `README`/`setup.py`
* replaces `flake8`/`isort` with `ruff` and removes `py.typed`

TODOs:
- [x] wait for the next release of `hfh`, then address https://github.com/huggingface/hffs/pull/10#discussion_r1073546356 and https://github.com/huggingface/hffs/pull/10#discussion_r1073613096