### PR TITLE
Update prepare_for_release with new huggingface_hub version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ from setuptools import find_packages, setup
 REQUIRED_PKGS = [
     "fsspec",
     "requests",
-    "huggingface_hub>=0.10.0",
+    "huggingface_hub>=0.12.0",
 ]
 
 

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -166,10 +166,13 @@ class HfFileSystemTests(unittest.TestCase):
             "hf://datasets/username/my_dataset@0123456789",
             {"repo_id": "username/my_dataset", "repo_type": "dataset", "revision": "0123456789"},
         ),
-        # Parse canonical repos (no namespace)
+        # Parse canonical models (no namespace)
         ("gpt2", {"repo_id": "gpt2", "repo_type": "model"}),
         ("hf://gpt2", {"repo_id": "gpt2", "repo_type": "model"}),
+        # Canonical datasets are not parsed correctly by huggingface_hub yet. They are processed separately by hffs.
+        ("datasets/squad", {"repo_id": "squad", "repo_type": "dataset"}),
+        ("hf://datasets/squad", {"repo_id": "squad", "repo_type": "dataset"}),
     ],
 )
-def test_parse_hffs_path(path: str, expected: Dict[str, str]) -> None:
+def test_parse_hffs_path_success(path: str, expected: Dict[str, str]) -> None:
     assert HfFileSystem._get_kwargs_from_urls(path) == expected


### PR DESCRIPTION
@lhoestq @mariosasko I've made an update to the `prepare_for_release` branch so that https://github.com/huggingface/hffs/pull/10 can finally be merged.

**Changes includes:**
- bump `huggingface_hub` version to `>=0.12.0`
- refactor `build_hf_headers` usage:
  - define library_name/library_version at `HfApi` creation
  - use `self._api._build_hf_headers(...)` to generate headers => no need to repeat args anymore
    - `HfApi()._build_hf_headers()` is private for now but really not meant to be change. I'm a bit sorry for that as it would be very convenient to have it public => I will do it but unfortunately only available in next `hfh` release. In the meantime, let's just use the private method (and I'll keep it the private one so that you are not impacted)
- removed `_repo_type_and_id_from_hf_id` in favor of `huggingface_hub.RepoUrl` to parse urls
  - also added a test there to check the cases we want to support. Please let me know if you want to add more examples. (Note: I used a simple test function instead of a `unittest.TestCase` class to be able to use the convenient `pytest.mark.parametrize` fixture but if you prefer to keep consistency, I can switch back)