### PR TITLE
Remove use of `set_access_token` in tests + small refacto

### DIFF
--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -305,14 +305,13 @@ class HfFileSystem(fsspec.AbstractFileSystem):
             raise FileNotFoundError(path)
         headers = self._api._build_hf_headers()
         revision = self.revision if self.revision is not None else huggingface_hub.constants.DEFAULT_REVISION
-        r = requests.get(
+
+        modified_date = None
+        for item in huggingface_hub.utils._pagination.paginate(
             f"{self.endpoint}/api/{self.repo_type}s/{self.repo_id}/tree/{quote(revision, safe='')}/{quote(self._parent(path), safe='')}"
             .rstrip("/"),
             headers=headers,
-        )
-        huggingface_hub.utils.hf_raise_for_status(r)
-        modified_date = None
-        for item in r.json()["items"]:
+        ):
             if item["type"] == "file" and item["path"] == path:
                 if PY_VERSION >= version.parse("3.11"):
                     modified_date = datetime.fromisoformat(item["lastCommit"]["author"]["date"])

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -307,9 +307,10 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         revision = self.revision if self.revision is not None else huggingface_hub.constants.DEFAULT_REVISION
 
         modified_date = None
-        for item in huggingface_hub.utils._pagination.paginate(
+        for item in huggingface_hub.hf_api.paginate(
             f"{self.endpoint}/api/{self.repo_type}s/{self.repo_id}/tree/{quote(revision, safe='')}/{quote(self._parent(path), safe='')}"
             .rstrip("/"),
+            params={},
             headers=headers,
         ):
             if item["type"] == "file" and item["path"] == path:

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -306,21 +306,19 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         headers = self._api._build_hf_headers()
         revision = self.revision if self.revision is not None else huggingface_hub.constants.DEFAULT_REVISION
 
-        modified_date = None
-        for item in huggingface_hub.hf_api.paginate(
-            f"{self.endpoint}/api/{self.repo_type}s/{self.repo_id}/tree/{quote(revision, safe='')}/{quote(self._parent(path), safe='')}"
-            .rstrip("/"),
-            params={},
+        response = requests.post(
+            f"{self.endpoint}/api/{self.repo_type}s/{self.repo_id}/paths-info/{quote(revision, safe='')}",
             headers=headers,
-        ):
-            if item["type"] == "file" and item["path"] == path:
-                if PY_VERSION >= version.parse("3.11"):
-                    modified_date = datetime.fromisoformat(item["lastCommit"]["author"]["date"])
-                else:
-                    modified_date = datetime.fromisoformat(item["lastCommit"]["author"]["date"].rstrip("Z"))
-                    modified_date = modified_date.replace(tzinfo=timezone.utc)
-                break
-        return modified_date
+            data={"paths": [path], "expand": True},
+        )
+        huggingface_hub.utils.hf_raise_for_status(response)
+        item = response.json()[0]
+
+        return (
+            datetime.fromisoformat(item["lastCommit"]["date"])
+            if PY_VERSION >= version.parse("3.11")
+            else datetime.fromisoformat(item["lastCommit"]["date"].rstrip("Z")).replace(tzinfo=timezone.utc)
+        )
 
 
 class HfFile(fsspec.spec.AbstractBufferedFile):

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -2,11 +2,10 @@ import datetime
 import time
 import unittest
 from typing import Dict
-
+from uuid import uuid4
 import fsspec
 import pytest
 from fsspec.spec import AbstractBufferedFile
-from huggingface_hub import HfApi
 
 from hffs import HfFileSystem
 
@@ -20,139 +19,115 @@ ENDPOINT_STAGING = "https://hub-ci.huggingface.co"
 class HfFileSystemTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls._api = HfApi(endpoint=ENDPOINT_STAGING)
-        cls._api.set_access_token(TOKEN)
-        cls._endpoint = ENDPOINT_STAGING
-        cls._token = TOKEN
-
         if HfFileSystem.protocol not in fsspec.available_protocols():
             fsspec.register_implementation(HfFileSystem.protocol, HfFileSystem)
 
-    @classmethod
-    def tearDownClass(cls):
-        cls._api.unset_access_token()
-
     def setUp(self):
-        repo_name = f"repo_data-{int(time.time() * 10e3)}"
-        repo_id = f"{USER}/{repo_name}"
-        self._api.create_repo(
-            repo_id,
-            token=self._token,
-            repo_type="dataset",
-            private=True,
-        )
-        self._api.upload_file(
+        self.repo_id = f"{USER}/hffs-test-repo-{uuid4()}"
+        self.repo_type = "dataset"
+        self.hffs = HfFileSystem(self.repo_id, endpoint=ENDPOINT_STAGING, token=TOKEN, repo_type=self.repo_type)
+        self.api = self._fs._api
+
+        # Create dumb repo
+        self.api.create_repo(self.repo_id, repo_type=self.repo_type, private=True)
+        self.api.upload_file(
             path_or_fileobj="dummy text data".encode("utf-8"),
             path_in_repo="data/text_data.txt",
-            repo_id=repo_id,
-            token=TOKEN,
-            repo_type="dataset",
+            repo_id=self.repo_id,
+            repo_type=self.repo_type,
         )
-        self._api.upload_file(
+        self.api.upload_file(
             path_or_fileobj=b"dummy binary data",
             path_in_repo="data/binary_data.bin",
-            repo_id=repo_id,
-            token=TOKEN,
-            repo_type="dataset",
+            repo_id=self.repo_id,
+            repo_type=self.repo_type,
         )
-        self.repo_id = repo_id
-        self.repo_type = "dataset"
 
     def tearDown(self):
-        self._api.delete_repo(self.repo_id, token=self._token, repo_type=self.repo_type)
+        self.api.delete_repo(self.repo_id, repo_type=self.repo_type)
 
     def test_glob(self):
-        hffs = HfFileSystem(self.repo_id, endpoint=self._endpoint, token=self._token, repo_type=self.repo_type)
-        self.assertEqual(sorted(hffs.glob("*")), sorted([".gitattributes", "data"]))
+        self.assertEqual(sorted(self.hffs.glob("*")), sorted([".gitattributes", "data"]))
 
     def test_file_type(self):
-        hffs = HfFileSystem(self.repo_id, endpoint=self._endpoint, token=self._token, repo_type=self.repo_type)
-        self.assertTrue(hffs.isdir("data") and not hffs.isdir(".gitattributes"))
-        self.assertTrue(hffs.isfile("data/text_data.txt") and not hffs.isfile("data"))
+        self.assertTrue(self.hffs.isdir("data") and not self.hffs.isdir(".gitattributes"))
+        self.assertTrue(self.hffs.isfile("data/text_data.txt") and not self.hffs.isfile("data"))
 
     def test_remove_file(self):
-        hffs = HfFileSystem(self.repo_id, endpoint=self._endpoint, token=self._token, repo_type=self.repo_type)
-        hffs.rm_file("data/text_data.txt")
-        self.assertEqual(hffs.glob("data/*"), ["data/binary_data.bin"])
+        self.hffs.rm_file("data/text_data.txt")
+        self.assertEqual(self.hffs.glob("data/*"), ["data/binary_data.bin"])
 
     def test_remove_directory(self):
-        hffs = HfFileSystem(self.repo_id, endpoint=self._endpoint, token=self._token, repo_type=self.repo_type)
-        hffs.rm("data", recursive=True)
-        self.assertNotIn("data", hffs.ls(""))
+        self.hffs.rm("data", recursive=True)
+        self.assertNotIn("data", self.hffs.ls(""))
 
     def test_read_file(self):
-        hffs = HfFileSystem(self.repo_id, endpoint=self._endpoint, token=self._token, repo_type=self.repo_type)
-        with hffs.open("data/text_data.txt", "r") as f:
+        with self.hffs.open("data/text_data.txt", "r") as f:
             self.assertEqual(f.read(), "dummy text data")
 
     def test_write_file(self):
-        hffs = HfFileSystem(self.repo_id, endpoint=self._endpoint, token=self._token, repo_type=self.repo_type)
         data = "new text data"
-        with hffs.open("data/new_text_data.txt", "w") as f:
+        with self.hffs.open("data/new_text_data.txt", "w") as f:
             f.write(data)
-        self.assertIn("data/new_text_data.txt", hffs.glob("data/*"))
-        with hffs.open("data/new_text_data.txt", "r") as f:
+        self.assertIn("data/new_text_data.txt", self.hffs.glob("data/*"))
+        with self.hffs.open("data/new_text_data.txt", "r") as f:
             self.assertEqual(f.read(), data)
 
     def test_write_file_multiple_chunks(self):
-        hffs = HfFileSystem(self.repo_id, endpoint=self._endpoint, token=self._token, repo_type=self.repo_type)
         data = "new text data big" * AbstractBufferedFile.DEFAULT_BLOCK_SIZE
-        with hffs.open("data/new_text_data_big.txt", "w") as f:
+        with self.hffs.open("data/new_text_data_big.txt", "w") as f:
             for _ in range(2):
                 f.write(data)
 
-        self.assertIn("data/new_text_data_big.txt", hffs.glob("data/*"))
-        with hffs.open("data/new_text_data_big.txt", "r") as f:
+        self.assertIn("data/new_text_data_big.txt", self.hffs.glob("data/*"))
+        with self.hffs.open("data/new_text_data_big.txt", "r") as f:
             for _ in range(2):
                 self.assertEqual(f.read(len(data)), data)
 
     @unittest.skip("Not implemented yet")
     def test_append_file(self):
-        hffs = HfFileSystem(self.repo_id, endpoint=self._endpoint, token=self._token, repo_type=self.repo_type)
-        with hffs.open("data/text_data.txt", "a") as f:
+        with self.hffs.open("data/text_data.txt", "a") as f:
             f.write(" appended text")
 
-        with hffs.open("data/text_data.txt", "r") as f:
+        with self.hffs.open("data/text_data.txt", "r") as f:
             self.assertEqual(f.read(), "dummy text data appended text")
 
     def test_copy_file(self):
-        hffs = HfFileSystem(self.repo_id, endpoint=self._endpoint, token=self._token, repo_type=self.repo_type)
         # Non-LFS file
-        self.assertIsNone(hffs.info("data/text_data.txt")["lfs"])
-        hffs.cp_file("data/text_data.txt", "data/text_data_copy.txt")
-        with hffs.open("data/text_data_copy.txt", "r") as f:
+        self.assertIsNone(self.hffs.info("data/text_data.txt")["lfs"])
+        self.hffs.cp_file("data/text_data.txt", "data/text_data_copy.txt")
+        with self.hffs.open("data/text_data_copy.txt", "r") as f:
             self.assertEqual(f.read(), "dummy text data")
-        self.assertIsNone(hffs.info("data/text_data_copy.txt")["lfs"])
+        self.assertIsNone(self.hffs.info("data/text_data_copy.txt")["lfs"])
         # LFS file
-        self.assertIsNotNone(hffs.info("data/binary_data.bin")["lfs"])
-        hffs.cp_file("data/binary_data.bin", "data/binary_data_copy.bin")
-        with hffs.open("data/binary_data_copy.bin", "rb") as f:
+        self.assertIsNotNone(self.hffs.info("data/binary_data.bin")["lfs"])
+        self.hffs.cp_file("data/binary_data.bin", "data/binary_data_copy.bin")
+        with self.hffs.open("data/binary_data_copy.bin", "rb") as f:
             self.assertEqual(f.read(), b"dummy binary data")
-        self.assertIsNotNone(hffs.info("data/binary_data_copy.bin")["lfs"])
+        self.assertIsNotNone(self.hffs.info("data/binary_data_copy.bin")["lfs"])
 
     def test_modified_time(self):
-        hffs = HfFileSystem(self.repo_id, endpoint=self._endpoint, token=self._token, repo_type=self.repo_type)
-        self.assertIsInstance(hffs.modified("data/text_data.txt"), datetime.datetime)
+        self.assertIsInstance(self.hffs.modified("data/text_data.txt"), datetime.datetime)
         # should fail on a non-existing file/directory
         with self.assertRaises(FileNotFoundError):
-            hffs.modified("data/not_existing_file.txt")
+            self.hffs.modified("data/not_existing_file.txt")
         # should fail on a directory
         with self.assertRaises(FileNotFoundError):
-            hffs.modified("data")
+            self.hffs.modified("data")
 
     def test_initialize_from_fsspec(self):
         fs, _, paths = fsspec.get_fs_token_paths(
             f"hf://{self.repo_type}/{self.repo_id}:/data/text_data.txt",
             storage_options={
-                "endpoint": self._endpoint,
-                "token": self._token,
+                "endpoint": ENDPOINT_STAGING,
+                "token": TOKEN,
                 "revision": "test-branch",
             },
         )
         self.assertIsInstance(fs, HfFileSystem)
-        self.assertEqual(fs._api.endpoint, self._endpoint)
+        self.assertEqual(fs._api.endpoint, ENDPOINT_STAGING)
         self.assertEqual(fs.repo_id, self.repo_id)
-        self.assertEqual(fs.token, self._token)
+        self.assertEqual(fs.token, TOKEN)
         self.assertEqual(fs.repo_type, self.repo_type)
         self.assertEqual(fs.revision, "test-branch")
         self.assertEqual(paths, ["data/text_data.txt"])

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,8 +1,8 @@
 import datetime
-import time
 import unittest
 from typing import Dict
 from uuid import uuid4
+
 import fsspec
 import pytest
 from fsspec.spec import AbstractBufferedFile

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -26,7 +26,7 @@ class HfFileSystemTests(unittest.TestCase):
         self.repo_id = f"{USER}/hffs-test-repo-{uuid4()}"
         self.repo_type = "dataset"
         self.hffs = HfFileSystem(self.repo_id, endpoint=ENDPOINT_STAGING, token=TOKEN, repo_type=self.repo_type)
-        self.api = self._fs._api
+        self.api = self.hffs._api
 
         # Create dumb repo
         self.api.create_repo(self.repo_id, repo_type=self.repo_type, private=True)


### PR DESCRIPTION
[`HfApi.set_access_token`](https://github.com/huggingface/huggingface_hub/blob/bf0f20850843e73dbfccb61a00881bd7eeb66428/src/huggingface_hub/hf_api.py#L868) is deprecated and will be removed in next version of `huggingface_hub`. This PR removes its usage in the tests. No big deal as it was not used anyway (`set_access_token` sets the token in git credential but git is not used in the docs).

While doing this I also refactored a bit the tests to remove duplicate code + made the tmp repo_id more unique. The tests can now be run in parallel using `pytest-xdist` if you'd like to speed-up CI. I can do it in the PR if you want @mariosasko  (I'm also fine if you think that adds unnecessary constraints on future tests). 


**EDIT:** also fixed the implementation of `modified` using the `/paths-info` endpoint (see https://github.com/huggingface/moon-landing/pull/5582 - internal link)