### PR TITLE
Redefine filesystem root

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Instantiation via `fsspec`:
 > hf://[<repo_type_prefix>]<repo_id>/<path/in/repo>
 > ```
 
-The prefix for datasets in "datasets/", the prefix for spaces is "spaces/" and models don't need a prefix in the URL.
+The prefix for datasets is "datasets/", the prefix for spaces is "spaces/" and models don't need a prefix in the URL.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Instantiation via `fsspec`:
 
 > **Note**: To be recognized as a `hffs` URL, the URL path passed to [`fsspec.open`](https://filesystem-spec.readthedocs.io/en/latest/api.html?highlight=open#fsspec.open) must adhere to the following scheme:
 > ```
-> hf://[<repo_type>/]<repo_id>[@<revision>]:/<path/in/repo>
+> hf://[<repo_type_prefix>/]<repo_id>/<path/in/repo>
 > ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Instantiation via `fsspec`:
 
 > **Note**: To be recognized as a `hffs` URL, the URL path passed to [`fsspec.open`](https://filesystem-spec.readthedocs.io/en/latest/api.html?highlight=open#fsspec.open) must adhere to the following scheme:
 > ```
-> hf://[<repo_type_prefix>/]<repo_id>/<path/in/repo>
+> hf://<repo_type>/<repo_id>/<path/in/repo>
 > ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Locate and read a file from a 🤗 Hub repo:
 
 ```python
 >>> import hffs
->>> fs = hffs.HfFileSystem("my-username/my-dataset-repo", repo_type="dataset")
->>> fs.ls("")
+>>> fs = hffs.HfFileSystem()
+>>> fs.ls("datasets/my-username/my-dataset-repo")
 ['.gitattributes', 'my-file.txt']
->>> with fs.open("my-file.txt", "r") as f:
+>>> with fs.open("datasets/my-username/my-dataset-repo/my-file.txt", "r") as f:
 ...     f.read()
 'Hello, world'
 ```
@@ -19,12 +19,12 @@ Locate and read a file from a 🤗 Hub repo:
 Write a file to the repo:
 
 ```python
->>> with fs.open("my-file-new.txt", "w") as f:
+>>> with fs.open("datasets/my-username/my-dataset-repo/my-file-new.txt", "w") as f:
 ...     f.write("Hello, world1")
 ...     f.write("Hello, world2")
->>> fs.exists("my-file-new.txt")
+>>> fs.exists("datasets/my-username/my-dataset-repo/my-file-new.txt")
 True
->>> fs.du("my-file-new.txt")
+>>> fs.du("datasets/my-username/my-dataset-repo/my-file-new.txt")
 26
 ```
 
@@ -34,12 +34,12 @@ Instantiation via `fsspec`:
 >>> import fsspec
 
 >>> # Instantiate a `hffs.HfFileSystem` object
->>> fs = fsspec.filesystem("hf://my-username/my-model-repo")
->>> fs.ls("")
+>>> fs = fsspec.filesystem("hf")
+>>> fs.ls("my-username/my-model-repo")
 ['.gitattributes', 'config.json', 'pytorch_model.bin']
 
 >>> # Instantiate a `hffs.HfFileSystem` object and write a file to it
->>> with fsspec.open("hf://datasets/my-username/my-dataset-repo:/my-file-new.txt"):
+>>> with fsspec.open("hf://datasets/my-username/my-dataset-repo/my-file-new.txt"):
 ...     f.write("Hello, world1")
 ...     f.write("Hello, world2")
 ```
@@ -63,10 +63,10 @@ pip install hffs
 >>> import pandas as pd
 
 >>> # Read a remote CSV file into a dataframe
->>> df = pd.read_csv("hf://datasets/my-username/my-dataset-repo:/train.csv")
+>>> df = pd.read_csv("hf://datasets/my-username/my-dataset-repo/train.csv")
 
 >>> # Write a dataframe to a remote CSV file
->>> df.to_csv("hf://datasets/my-username/my-dataset-repo:/test.csv")
+>>> df.to_csv("hf://datasets/my-username/my-dataset-repo/test.csv")
 ```
 
 * [`datasets`](https://huggingface.co/docs/datasets/filesystems#load-and-save-your-datasets-using-your-cloud-storage-filesystem)
@@ -75,12 +75,12 @@ pip install hffs
 >>> import datasets
 
 >>> # Export a (large) dataset to a repo
->>> cache_dir = "hf://datasets/my-username/my-dataset-repo"
->>> builder = datasets.load_dataset_builder("path/to/local/loading_script/loading_script.py", cache_dir=cache_dir)
->>> builder.download_and_prepare(file_format="parquet")
+>>> output_dir = "hf://datasets/my-username/my-dataset-repo"
+>>> builder = datasets.load_dataset_builder("path/to/local/loading_script/loading_script.py")
+>>> builder.download_and_prepare(output_dir, file_format="parquet")
 
 >>> # Stream the dataset from the repo
->>> dset = datasets.load_dataset("my-username/my-dataset-repo", split="train")
+>>> dset = datasets.load_dataset("my-username/my-dataset-repo", split="train", streaming=True)
 >>> # Process the examples
 >>> for ex in dset:
 ...    ...
@@ -95,13 +95,13 @@ pip install hffs
 >>> embeddings = np.random.randn(50000, 1000).astype("float32")
 
 >>> # Write an array to a repo acting as a remote zarr store
->>> with zarr.open_group("hf://my-username/my-model-repo:/array-store", mode="w") as root:
+>>> with zarr.open_group("hf://my-username/my-model-repo/array-store", mode="w") as root:
 ...    foo = root.create_group("embeddings")
 ...    foobar = foo.zeros('experiment_0', shape=(50000, 1000), chunks=(10000, 1000), dtype='f4')
 ...    foobar[:] = embeddings
 
 >>> # Read from a remote zarr store
->>> with zarr.open_group("hf://my-username/my-model-repo:/array-store", mode="r") as root:
+>>> with zarr.open_group("hf://my-username/my-model-repo/array-store", mode="r") as root:
 ...    first_row = root["embeddings/experiment_0"][0]
 ```
 
@@ -111,8 +111,30 @@ pip install hffs
 >>> import hffs
 >>> import duckdb
 
->>> fs = hffs.HfFileSystem("my-username/my-dataset-repo", repo_type="dataset")
+>>> fs = hffs.HfFileSystem()
 >>> duckdb.register_filesystem(fs)
 >>> # Query a remote file and get the result as a dataframe
->>> df = duckdb.query("SELECT * FROM 'hf://data.parquet' LIMIT 10").df()
+>>> df = duckdb.query("SELECT * FROM 'hf://datasets/my-username/my-dataset-repo/data.parquet' LIMIT 10").df()
+```
+
+## Authentication
+
+To write to your repotitories or access your private repositorories; you can login by running
+
+```bash
+huggingface-cli login
+```
+
+Or pass a token (from your [HF settings](https://huggingface.co/settings/tokens)) to
+
+```python
+>>> import hffs
+>>> fs = hffs.HfFileSystem(token=token)
+```
+
+or as `storage_options`:
+
+```python
+>>> storage_options = {"token": token}
+>>> df = pd.read_csv("hf://datasets/my-username/my-dataset-repo/train.csv", storage_options=storage_options)
 ```

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ Instantiation via `fsspec`:
 
 > **Note**: To be recognized as a `hffs` URL, the URL path passed to [`fsspec.open`](https://filesystem-spec.readthedocs.io/en/latest/api.html?highlight=open#fsspec.open) must adhere to the following scheme:
 > ```
-> hf://<repo_type>/<repo_id>/<path/in/repo>
+> hf://[<repo_type_prefix>]<repo_id>/<path/in/repo>
 > ```
+
+The prefix for datasets in "datasets/", the prefix for spaces is "spaces/" and models don't need a prefix in the URL.
 
 ## Installation
 

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -87,9 +87,9 @@ class HfFileSystem(fsspec.AbstractFileSystem):
     >>> import fsspec
 
     >>> # Read/write files
-    >>> with fsspec.open("hf://my-username/my-model/model.bin") as f:
+    >>> with fsspec.open("hf://my-username/my-model/pytorch_model.bin") as f:
     ...     data = f.read()
-    >>> with fsspec.open("hf://my-username/my-model/model.bin", "wb") as f:
+    >>> with fsspec.open("hf://my-username/my-model/pytorch_model.bin", "wb") as f:
     ...     f.write(data)
     ```
     """

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -4,7 +4,7 @@ import platform
 import tempfile
 from datetime import datetime, timezone
 from pathlib import PurePosixPath
-from typing import Optional
+from typing import Optional, Tuple
 from urllib.parse import quote
 
 import fsspec
@@ -113,7 +113,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
             endpoint=endpoint, token=token, library_name="hffs", library_version=__version__
         )
 
-    def _resolve_repo_id(self, path: str) -> tuple[str, str, str]:
+    def _resolve_repo_id(self, path: str) -> Tuple[str, str, str]:
         path = self._strip_protocol(path)
         if path.split("/")[0] in huggingface_hub.constants.REPO_TYPES_MAPPING:
             if "/" not in path:

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -71,7 +71,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
     >>> # List files
     >>> fs.glob("my-username/my-model/*.bin")
     ["pytorch_model.bin"]
-    >>> fs.ls("datasets/my-username/my-dataset", detail=false)
+    >>> fs.ls("datasets/my-username/my-dataset", detail=False)
     ['.gitattributes', 'README.md', 'data.json']
 
     >>> # Read/write files

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -1,7 +1,6 @@
 import collections
 import os
 import platform
-import re
 import tempfile
 from datetime import datetime, timezone
 from pathlib import PurePosixPath
@@ -51,18 +50,11 @@ class HfFileSystem(fsspec.AbstractFileSystem):
     Access a remote Hugging Face Hub repository as if were a local file system.
 
     Args:
-        repo_id (`str`):
-            The remote repository to access as if were a local file system,
-            for example: `"username/custom_transformers"`
         endpoint (`str`, *optional*):
             The endpoint to use. If not provided, the default one (https://huggingface.co) is used.
         token (`str`, *optional*):
             Authentication token, obtained with `HfApi.login` method. Will
             default to the stored token.
-        repo_type (`str`, *optional*):
-            Set to `"dataset"` or `"space"` if the remote repositry is a dataset or
-            space repositroy, `None` or `"model"` if it is a model repository. Default is
-            `None`.
         revision (`str`, *optional*):
             An optional Git revision id which can be a branch name, a tag, or a
             commit hash. Defaults to the head of the `"main"` branch.
@@ -72,14 +64,30 @@ class HfFileSystem(fsspec.AbstractFileSystem):
     ```python
     >>> import hffs
 
-    >>> fs = hffs.HfFileSystem("username/my-dataset", repo_type="dataset")
+    >>> fs = hffs.HfFileSystem()
 
-    >>> # Read a remote file
-    >>> with fs.open("remote/file/in/repo.bin") as f:
+    >>> # Read a remote model file
+    >>> with fs.open("my-username/my-model/model.bin") as f:
     ...     data = f.read()
 
-    >>> # Write a remote file
-    >>> with fs.open("remote/file/in/repo.bin", "wb") as f:
+    >>> # Write a remote model file
+    >>> with fs.open("my-username/my-model/model.bin", "wb") as f:
+    ...     f.write(data)
+
+    >>> # Read a remote dataset file
+    >>> with fs.open("datasets/my-username/my-dataset/data.json", "r") as f:
+    ...     data = f.read()
+
+    >>> # Write a remote dataset file
+    >>> with fs.open("datasets/my-username/my-dataset/data.json", "w") as f:
+    ...     f.write(data)
+
+    >>> # Read a remote space file
+    >>> with fs.open("spaces/my-username/my-space/app.py", "r") as f:
+    ...     data = f.read()
+
+    >>> # Write a remote space file
+    >>> with fs.open("spaces/my-username/my-space/app.py", "w") as f:
     ...     f.write(data)
     ```
 
@@ -89,11 +97,11 @@ class HfFileSystem(fsspec.AbstractFileSystem):
     >>> import fsspec
 
     >>> # Read a remote file
-    >>> with fsspec.open("hf://datasets/my-username/my-dataset:/remote/file/in/repo.bin") as f:
+    >>> with fsspec.open("hf://my-username/my-model/model.bin") as f:
     ...     data = f.read()
 
     >>> # Write a remote file
-    >>> with fsspec.open("hf://datasets/my-username/my-dataset:/remote/file/in/repo.bin", "wb") as f:
+    >>> with fsspec.open("hf://my-username/my-model/model.bin", "wb") as f:
     ...     f.write(data)
     ```
     """
@@ -101,45 +109,73 @@ class HfFileSystem(fsspec.AbstractFileSystem):
     root_marker = ""
     protocol = "hf"
 
-    @huggingface_hub.utils.validate_hf_hub_args
     def __init__(
         self,
-        repo_id: str,
+        *args,
         token: Optional[str] = None,
-        repo_type: Optional[str] = None,
-        revision: Optional[str] = None,
         endpoint: Optional[str] = None,
-        **kwargs,
+        revision: Optional[str] = None,
+        **storage_options,
     ):
-        super().__init__(self, **kwargs)
-
-        if repo_type not in huggingface_hub.constants.REPO_TYPES:
-            raise ValueError(f"Invalid repo type, must be one of {huggingface_hub.constants.REPO_TYPES}")
-
-        self.repo_id = repo_id
-        self.endpoint = endpoint if endpoint is not None else huggingface_hub.constants.ENDPOINT
-        self.token = token if token is not None else huggingface_hub.HfFolder.get_token()
-        self.repo_type = repo_type if repo_type is not None else huggingface_hub.constants.REPO_TYPE_MODEL
+        super().__init__(*args, **storage_options)
+        self.token = token
+        self.endpoint = endpoint
         self.revision = revision
         self._api = huggingface_hub.HfApi(
             endpoint=endpoint, token=token, library_name="hffs", library_version=__version__
         )
 
-    def _dircache_from_repo_info(self):
-        repo_info = self._api.repo_info(
-            self.repo_id, revision=self.revision, repo_type=self.repo_type, token=self.token, files_metadata=True
-        )
+    def _resolve_repo_id(self, path: str) -> tuple[str, str, str]:
+        path = self._strip_protocol(path)
+        if path.split("/")[0] in huggingface_hub.constants.REPO_TYPES_MAPPING:
+            if "/" not in path:
+                raise NotImplementedError("Listing repositories is not implemented.")
+            repo_type, path = path.split("/", 1)
+            repo_type = huggingface_hub.constants.REPO_TYPES_MAPPING[repo_type]
+        else:
+            repo_type = None
+        if path.count("/") > 0:
+            try:
+                namespace, repo_name, *parts_in_repo = path.split("/")
+                repo_id_with_namespace = f"{namespace}/{repo_name}"
+                self._api.repo_info(repo_id_with_namespace, repo_type=repo_type)
+                repo_id = repo_id_with_namespace
+            except huggingface_hub.utils.RepositoryNotFoundError:
+                try:
+                    repo_id_without_namespace, *parts_in_repo = path.split("/")
+                    self._api.repo_info(repo_id_without_namespace, repo_type=repo_type)
+                    repo_id = repo_id_without_namespace
+                except huggingface_hub.utils.RepositoryNotFoundError:
+                    raise FileNotFoundError(f"No such repository: '{repo_id_with_namespace}'")
+        else:
+            try:
+                repo_id, parts_in_repo = path, []
+                self._api.repo_info(path, repo_type=repo_type)
+            except huggingface_hub.utils.RepositoryNotFoundError:
+                raise FileNotFoundError(f"No such repository: '{repo_id}'")
+        path_in_repo = "/".join(parts_in_repo)
+        return repo_type, repo_id, path_in_repo
+
+    def _dircache_from_repo_info(self, path: str):
+        repo_type, repo_id, _ = self._resolve_repo_id(path)
+        repo_info = self._api.repo_info(repo_id, revision=self.revision, repo_type=repo_type, files_metadata=True)
         child_dirs = collections.defaultdict(set)
         for repo_file in repo_info.siblings:
+            hf_path = (
+                huggingface_hub.constants.REPO_TYPES_URL_PREFIXES.get(repo_type, "")
+                + repo_id
+                + "/"
+                + repo_file.rfilename
+            )
             child = {
-                "name": repo_file.rfilename,
+                "name": hf_path,
                 "size": repo_file.size,
                 "type": "file",
                 # extra metadata for files
                 "blob_id": repo_file.blob_id,
                 "lfs": repo_file.lfs,
             }
-            parents = list(PurePosixPath(repo_file.rfilename).parents)[:-1] + [self.root_marker]
+            parents = list(PurePosixPath(hf_path).parents)[:-1] + [self.root_marker]
             parent = str(parents[0])
             self.dircache.setdefault(str(parent), []).append(child)
             child = {"name": parent, "size": None, "type": "directory"}
@@ -156,49 +192,6 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         # TODO: use `path` to optimize cache invalidation -> requires filtering on the server to be implemented efficiently
         self.dircache.clear()
 
-    @classmethod
-    def _strip_protocol(cls, path):
-        if isinstance(path, list):
-            return [cls._strip_protocol(fsspec.utils.stringify_path(p)) for p in path]
-        protocol = cls.protocol
-        if path.startswith(protocol + "://"):
-            path = path[len(protocol + "://") :]
-            hf_id, *paths = path.split(":/", 1)
-            path = paths[0] if paths else cls.root_marker
-        # TODO: the hack below is needed to work with DuckDB, remove it as soon as it is fixed on their side
-        if path.startswith(("dataset", "model", "space")) and ":/" in path:
-            hf_id, *paths = path.split(":/", 1)
-            path = paths[0] if paths else cls.root_marker
-        return path
-
-    def unstrip_protocol(self, path):
-        return super().unstrip_protocol(
-            f"{self.repo_type}s/{self.repo_id}{'@' + self.revision if self.revision is not None else ''}:/{path}"
-        )
-
-    @staticmethod
-    def _get_kwargs_from_urls(path):
-        protocol = HfFileSystem.protocol
-        if path.startswith(protocol + "://"):
-            path = path[len(protocol + "://") :]
-        hf_id, *paths = path.split(":/", 1)
-        hf_id, *revisions = hf_id.split("@", 1)
-        parsed_id = huggingface_hub.RepoUrl(hf_id)
-
-        out = {}
-        out["repo_id"] = parsed_id.repo_id
-        out["repo_type"] = parsed_id.repo_type
-        if revisions:
-            out["revision"] = revisions[0]
-
-        # Corner case for `huggingface_hub<=0.13.0`: canonical datasets URLs are not parsed correctly by `huggingface_hub`
-        if HFH_VERSION < version.parse("0.13.0") and out["repo_type"] == "model":
-            match = re.match(r"datasets?/(?P<repo_id>.*)", out["repo_id"])
-            if match is not None:
-                out["repo_type"], out["repo_id"] = "dataset", match.groupdict()["repo_id"]
-
-        return out
-
     def _open(
         self,
         path: str,
@@ -211,12 +204,13 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         return HfFile(self, path, mode=mode, **kwargs)
 
     def _rm(self, path, **kwargs):
+        repo_type, repo_id, path_in_repo = self._resolve_repo_id(path)
         path = self._strip_protocol(path)
-        operations = [huggingface_hub.CommitOperationDelete(path_in_repo=path)]
+        operations = [huggingface_hub.CommitOperationDelete(path_in_repo=path_in_repo)]
         commit_message = f"Delete {path}"
         self._api.create_commit(
-            repo_id=self.repo_id,
-            repo_type=self.repo_type,
+            repo_id=repo_id,
+            repo_type=repo_type,
             token=self.token,
             operations=operations,
             revision=self.revision,
@@ -226,16 +220,20 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         self.invalidate_cache()
 
     def rm(self, path, recursive=False, maxdepth=None, **kwargs):
+        repo_type, repo_id, _ = self._resolve_repo_id(path)
+        root_path = huggingface_hub.constants.REPO_TYPES_URL_PREFIXES.get(repo_type, "") + repo_id
         paths = self.expand_path(path, recursive=recursive, maxdepth=maxdepth)
-        file_paths = [path for path in paths if not self.isdir(path)]
-        operations = [huggingface_hub.CommitOperationDelete(path_in_repo=file_path) for file_path in file_paths]
+        paths_in_repo = [path[len(root_path) + 1 :] for path in paths if not self.isdir(path)]
+        operations = [
+            huggingface_hub.CommitOperationDelete(path_in_repo=path_in_repo) for path_in_repo in paths_in_repo
+        ]
         commit_message = f"Delete {path} "
         commit_message += "recursively " if recursive else ""
         commit_message += f"up to depth {maxdepth} " if maxdepth is not None else ""
         # TODO: use `commit_description` to list all the deleted paths?
         self._api.create_commit(
-            repo_id=self.repo_id,
-            repo_type=self.repo_type,
+            repo_id=repo_id,
+            repo_type=repo_type,
             token=self.token,
             operations=operations,
             revision=self.revision,
@@ -246,8 +244,11 @@ class HfFileSystem(fsspec.AbstractFileSystem):
 
     def ls(self, path, detail=True, **kwargs):
         path = self._strip_protocol(path)
-        if not self.dircache:
-            self._dircache_from_repo_info()
+        if not path:
+            raise NotImplementedError("Listing repositories is not implemented.")
+        out = self._ls_from_cache(path)
+        if not out:
+            self._dircache_from_repo_info(path)
         out = self._ls_from_cache(path)
         if out is None:
             raise FileNotFoundError(path)
@@ -256,11 +257,15 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         return [o["name"] for o in out]
 
     def cp_file(self, path1, path2, **kwargs):
+        repo_type1, repo_id1, path_in_repo1 = self._resolve_repo_id(path1)
         path1 = self._strip_protocol(path1)
+        repo_type2, repo_id2, path_in_repo2 = self._resolve_repo_id(path2)
         path2 = self._strip_protocol(path2)
 
+        same_repo = repo_type1 == repo_type2 and repo_id1 == repo_id2
+
         # TODO: Wait for https://github.com/huggingface/huggingface_hub/issues/1083 to be resolved to simplify this logic
-        if self.info(path1)["lfs"] is not None:
+        if same_repo and self.info(path1)["lfs"] is not None:
             headers = self._api._build_hf_headers(is_write_action=True)
             commit_message = f"Copy {path1} to {path2}"
             payload = {
@@ -269,7 +274,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
                 "files": [],
                 "lfsFiles": [
                     {
-                        "path": path2,
+                        "path": path_in_repo2,
                         "algo": "sha256",
                         "oid": self.info(path1)["lfs"]["sha256"],
                     }
@@ -278,7 +283,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
             }
             revision = self.revision if self.revision is not None else huggingface_hub.constants.DEFAULT_REVISION
             r = requests.post(
-                f"{self.endpoint}/api/{self.repo_type}s/{self.repo_id}/commit/{quote(revision, safe='')}",
+                f"{self.endpoint}/api/{repo_type1}s/{repo_id1}/commit/{quote(revision, safe='')}",
                 json=payload,
                 headers=headers,
             )
@@ -289,10 +294,10 @@ class HfFileSystem(fsspec.AbstractFileSystem):
             commit_message = f"Copy {path1} to {path2}"
             self._api.upload_file(
                 path_or_fileobj=content,
-                path_in_repo=path2,
-                repo_id=self.repo_id,
+                path_in_repo=path_in_repo2,
+                repo_id=repo_id2,
                 token=self.token,
-                repo_type=self.repo_type,
+                repo_type=repo_type2,
                 revision=self.revision,
                 commit_message=kwargs.get("commit_message", commit_message),
                 commit_description=kwargs.get("commit_description"),
@@ -301,15 +306,16 @@ class HfFileSystem(fsspec.AbstractFileSystem):
 
     def modified(self, path):
         path = self._strip_protocol(path)
+        repo_type, repo_id, path_in_repo = self._resolve_repo_id(path)
         if not self.isfile(path):
             raise FileNotFoundError(path)
         headers = self._api._build_hf_headers()
         revision = self.revision if self.revision is not None else huggingface_hub.constants.DEFAULT_REVISION
 
         response = requests.post(
-            f"{self.endpoint}/api/{self.repo_type}s/{self.repo_id}/paths-info/{quote(revision, safe='')}",
+            f"{self.endpoint}/api/{repo_type}s/{repo_id}/paths-info/{quote(revision, safe='')}",
             headers=headers,
-            data={"paths": [path], "expand": True},
+            data={"paths": [path_in_repo], "expand": True},
         )
         huggingface_hub.utils.hf_raise_for_status(response)
         item = response.json()[0]
@@ -322,16 +328,21 @@ class HfFileSystem(fsspec.AbstractFileSystem):
 
 
 class HfFile(fsspec.spec.AbstractBufferedFile):
+    def __init__(self, fs: HfFileSystem, path: str, **kwargs):
+        super().__init__(fs, path, **kwargs)
+        self.fs: HfFileSystem
+        self.repo_type, self.repo_id, self.path_in_repo = fs._resolve_repo_id(path)
+
     def _fetch_range(self, start, end):
         headers = {
             "range": f"bytes={start}-{end}",
             **self.fs._api._build_hf_headers(),
         }
         url = _path_to_http_url(
-            self.path,
-            self.fs.repo_id,
+            self.path_in_repo,
+            self.repo_id,
             endpoint=self.fs.endpoint,
-            repo_type=self.fs.repo_type,
+            repo_type=self.repo_type,
             revision=self.fs.revision,
         )
         r = huggingface_hub.utils.http_backoff("GET", url, headers=headers)
@@ -350,10 +361,10 @@ class HfFile(fsspec.spec.AbstractBufferedFile):
             commit_message = f"Upload {self.path}"
             self.fs._api.upload_file(
                 path_or_fileobj=self.temp_file.name,
-                path_in_repo=self.path,
-                repo_id=self.fs.repo_id,
+                path_in_repo=self.path_in_repo,
+                repo_id=self.repo_id,
                 token=self.fs.token,
-                repo_type=self.fs.repo_type,
+                repo_type=self.repo_type,
                 revision=self.fs.revision,
                 commit_message=self.kwargs.get("commit_message", commit_message),
                 commit_description=self.kwargs.get("commit_description"),

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -330,12 +330,10 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         )
 
     def info(self, path, **kwargs):
-        # Fill cache first
-        try:
-            # pick an arbitrary path inside the repository
-            self.ls((path + "/foo") if path else "foo")
-        except (FileNotFoundError, NotImplementedError):
-            pass
+        path = self._strip_protocol(path)
+        repo_type, repo_id, path_in_repo = self._resolve_repo_id(path)
+        if not path_in_repo:
+            return {"name": path, "size": None, "type": "directory"}
         return super().info(path, **kwargs)
 
 

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -61,33 +61,23 @@ class HfFileSystem(fsspec.AbstractFileSystem):
 
     Direct usage:
 
+    Models:
+
     ```python
     >>> import hffs
 
     >>> fs = hffs.HfFileSystem()
 
-    >>> # Read a remote model file
-    >>> with fs.open("my-username/my-model/model.bin") as f:
+    >>> # List files
+    >>> fs.glob("my-username/my-model/*.bin")
+    ["pytorch_model.bin"]
+    >>> fs.ls("datasets/my-username/my-dataset", detail=false)
+    ['.gitattributes', 'README.md', 'data.json']
+
+    >>> # Read/write files
+    >>> with fs.open("my-username/my-model/pytorch_model.bin") as f:
     ...     data = f.read()
-
-    >>> # Write a remote model file
-    >>> with fs.open("my-username/my-model/model.bin", "wb") as f:
-    ...     f.write(data)
-
-    >>> # Read a remote dataset file
-    >>> with fs.open("datasets/my-username/my-dataset/data.json", "r") as f:
-    ...     data = f.read()
-
-    >>> # Write a remote dataset file
-    >>> with fs.open("datasets/my-username/my-dataset/data.json", "w") as f:
-    ...     f.write(data)
-
-    >>> # Read a remote space file
-    >>> with fs.open("spaces/my-username/my-space/app.py", "r") as f:
-    ...     data = f.read()
-
-    >>> # Write a remote space file
-    >>> with fs.open("spaces/my-username/my-space/app.py", "w") as f:
+    >>> with fs.open("my-username/my-model/pytorch_model.bin", "wb") as f:
     ...     f.write(data)
     ```
 
@@ -96,11 +86,9 @@ class HfFileSystem(fsspec.AbstractFileSystem):
     ```python
     >>> import fsspec
 
-    >>> # Read a remote file
+    >>> # Read/write files
     >>> with fsspec.open("hf://my-username/my-model/model.bin") as f:
     ...     data = f.read()
-
-    >>> # Write a remote file
     >>> with fsspec.open("hf://my-username/my-model/model.bin", "wb") as f:
     ...     f.write(data)
     ```

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -122,7 +122,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
                 self._api.repo_info(repo_id, repo_type=repo_type)
                 self._repository_type_and_id_exists_cache[(repo_type, repo_id)] = True
                 return True
-            except huggingface_hub.utils.RepositoryNotFoundError:
+            except (huggingface_hub.utils.RepositoryNotFoundError, huggingface_hub.utils.HFValidationError):
                 self._repository_type_and_id_exists_cache[(repo_type, repo_id)] = False
                 return False
 
@@ -345,7 +345,7 @@ class HfFile(fsspec.spec.AbstractBufferedFile):
 
     def _fetch_range(self, start, end):
         headers = {
-            "range": f"bytes={start}-{end}",
+            "range": f"bytes={start}-{end - 1}",
             **self.fs._api._build_hf_headers(),
         }
         url = _path_to_http_url(

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -382,6 +382,6 @@ class HfFile(fsspec.spec.AbstractBufferedFile):
                 commit_description=self.kwargs.get("commit_description"),
             )
             os.remove(self.temp_file.name)
-            self.invalidate_cache(
+            self.fs.invalidate_cache(
                 path=huggingface_hub.constants.REPO_TYPES_URL_PREFIXES.get(self.repo_type, "") + self.repo_id
             )

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,11 +1,12 @@
 import datetime
 import unittest
-from typing import Dict
+from typing import Optional
+from unittest.mock import patch
 from uuid import uuid4
 
 import fsspec
+import huggingface_hub
 import pytest
-from fsspec.spec import AbstractBufferedFile
 
 from hffs import HfFileSystem
 
@@ -25,11 +26,13 @@ class HfFileSystemTests(unittest.TestCase):
     def setUp(self):
         self.repo_id = f"{USER}/hffs-test-repo-{uuid4()}"
         self.repo_type = "dataset"
-        self.hffs = HfFileSystem(self.repo_id, endpoint=ENDPOINT_STAGING, token=TOKEN, repo_type=self.repo_type)
+        self.repo_prefix = huggingface_hub.constants.REPO_TYPES_URL_PREFIXES.get(self.repo_type, "")
+        self.hf_path = self.repo_prefix + self.repo_id
+        self.hffs = HfFileSystem(endpoint=ENDPOINT_STAGING, token=TOKEN)
         self.api = self.hffs._api
 
         # Create dumb repo
-        self.api.create_repo(self.repo_id, repo_type=self.repo_type, private=True)
+        self.api.create_repo(self.repo_id, repo_type=self.repo_type, private=False)
         self.api.upload_file(
             path_or_fileobj="dummy text data".encode("utf-8"),
             path_in_repo="data/text_data.txt",
@@ -47,77 +50,85 @@ class HfFileSystemTests(unittest.TestCase):
         self.api.delete_repo(self.repo_id, repo_type=self.repo_type)
 
     def test_glob(self):
-        self.assertEqual(sorted(self.hffs.glob("*")), sorted([".gitattributes", "data"]))
+        self.assertEqual(
+            sorted(self.hffs.glob(self.hf_path + "/*")),
+            sorted([self.hf_path + "/.gitattributes", self.hf_path + "/data"]),
+        )
 
     def test_file_type(self):
-        self.assertTrue(self.hffs.isdir("data") and not self.hffs.isdir(".gitattributes"))
-        self.assertTrue(self.hffs.isfile("data/text_data.txt") and not self.hffs.isfile("data"))
+        self.assertTrue(
+            self.hffs.isdir(self.hf_path + "/data") and not self.hffs.isdir(self.hf_path + "/.gitattributes")
+        )
+        self.assertTrue(
+            self.hffs.isfile(self.hf_path + "/data/text_data.txt") and not self.hffs.isfile(self.hf_path + "/data")
+        )
 
     def test_remove_file(self):
-        self.hffs.rm_file("data/text_data.txt")
-        self.assertEqual(self.hffs.glob("data/*"), ["data/binary_data.bin"])
+        self.hffs.rm_file(self.hf_path + "/data/text_data.txt")
+        self.assertEqual(self.hffs.glob(self.hf_path + "/data/*"), [self.hf_path + "/data/binary_data.bin"])
 
     def test_remove_directory(self):
-        self.hffs.rm("data", recursive=True)
-        self.assertNotIn("data", self.hffs.ls(""))
+        self.hffs.rm(self.hf_path + "/data", recursive=True)
+        self.assertNotIn(self.hf_path + "/data", self.hffs.ls(self.hf_path))
 
     def test_read_file(self):
-        with self.hffs.open("data/text_data.txt", "r") as f:
+        with self.hffs.open(self.hf_path + "/data/text_data.txt", "r") as f:
             self.assertEqual(f.read(), "dummy text data")
 
     def test_write_file(self):
         data = "new text data"
-        with self.hffs.open("data/new_text_data.txt", "w") as f:
+        with self.hffs.open(self.hf_path + "/data/new_text_data.txt", "w") as f:
             f.write(data)
-        self.assertIn("data/new_text_data.txt", self.hffs.glob("data/*"))
-        with self.hffs.open("data/new_text_data.txt", "r") as f:
+        self.assertIn(self.hf_path + "/data/new_text_data.txt", self.hffs.glob(self.hf_path + "/data/*"))
+        with self.hffs.open(self.hf_path + "/data/new_text_data.txt", "r") as f:
             self.assertEqual(f.read(), data)
 
     def test_write_file_multiple_chunks(self):
-        data = "new text data big" * AbstractBufferedFile.DEFAULT_BLOCK_SIZE
-        with self.hffs.open("data/new_text_data_big.txt", "w") as f:
-            for _ in range(2):
+        # TODO: try with files between 10 and 50MB (as of 16 March 2023 I was getting 504 errors on hub-ci)
+        data = "a" * (4 << 20)  # 4MB
+        with self.hffs.open(self.hf_path + "/data/new_text_data_big.txt", "w") as f:
+            for _ in range(2):  # 8MB in total
                 f.write(data)
 
-        self.assertIn("data/new_text_data_big.txt", self.hffs.glob("data/*"))
-        with self.hffs.open("data/new_text_data_big.txt", "r") as f:
+        self.assertIn(self.hf_path + "/data/new_text_data_big.txt", self.hffs.glob(self.hf_path + "/data/*"))
+        with self.hffs.open(self.hf_path + "/data/new_text_data_big.txt", "r") as f:
             for _ in range(2):
                 self.assertEqual(f.read(len(data)), data)
 
     @unittest.skip("Not implemented yet")
     def test_append_file(self):
-        with self.hffs.open("data/text_data.txt", "a") as f:
+        with self.hffs.open(self.hf_path + "/data/text_data.txt", "a") as f:
             f.write(" appended text")
 
-        with self.hffs.open("data/text_data.txt", "r") as f:
+        with self.hffs.open(self.hf_path + "/data/text_data.txt", "r") as f:
             self.assertEqual(f.read(), "dummy text data appended text")
 
     def test_copy_file(self):
         # Non-LFS file
-        self.assertIsNone(self.hffs.info("data/text_data.txt")["lfs"])
-        self.hffs.cp_file("data/text_data.txt", "data/text_data_copy.txt")
-        with self.hffs.open("data/text_data_copy.txt", "r") as f:
+        self.assertIsNone(self.hffs.info(self.hf_path + "/data/text_data.txt")["lfs"])
+        self.hffs.cp_file(self.hf_path + "/data/text_data.txt", self.hf_path + "/data/text_data_copy.txt")
+        with self.hffs.open(self.hf_path + "/data/text_data_copy.txt", "r") as f:
             self.assertEqual(f.read(), "dummy text data")
-        self.assertIsNone(self.hffs.info("data/text_data_copy.txt")["lfs"])
+        self.assertIsNone(self.hffs.info(self.hf_path + "/data/text_data_copy.txt")["lfs"])
         # LFS file
-        self.assertIsNotNone(self.hffs.info("data/binary_data.bin")["lfs"])
-        self.hffs.cp_file("data/binary_data.bin", "data/binary_data_copy.bin")
-        with self.hffs.open("data/binary_data_copy.bin", "rb") as f:
+        self.assertIsNotNone(self.hffs.info(self.hf_path + "/data/binary_data.bin")["lfs"])
+        self.hffs.cp_file(self.hf_path + "/data/binary_data.bin", self.hf_path + "/data/binary_data_copy.bin")
+        with self.hffs.open(self.hf_path + "/data/binary_data_copy.bin", "rb") as f:
             self.assertEqual(f.read(), b"dummy binary data")
-        self.assertIsNotNone(self.hffs.info("data/binary_data_copy.bin")["lfs"])
+        self.assertIsNotNone(self.hffs.info(self.hf_path + "/data/binary_data_copy.bin")["lfs"])
 
     def test_modified_time(self):
-        self.assertIsInstance(self.hffs.modified("data/text_data.txt"), datetime.datetime)
+        self.assertIsInstance(self.hffs.modified(self.hf_path + "/data/text_data.txt"), datetime.datetime)
         # should fail on a non-existing file/directory
         with self.assertRaises(FileNotFoundError):
-            self.hffs.modified("data/not_existing_file.txt")
+            self.hffs.modified(self.hf_path + "/data/not_existing_file.txt")
         # should fail on a directory
         with self.assertRaises(FileNotFoundError):
-            self.hffs.modified("data")
+            self.hffs.modified(self.hf_path + "/data")
 
     def test_initialize_from_fsspec(self):
         fs, _, paths = fsspec.get_fs_token_paths(
-            f"hf://{self.repo_type}/{self.repo_id}:/data/text_data.txt",
+            f"hf://{self.repo_type}s/{self.repo_id}/data/text_data.txt",
             storage_options={
                 "endpoint": ENDPOINT_STAGING,
                 "token": TOKEN,
@@ -126,39 +137,44 @@ class HfFileSystemTests(unittest.TestCase):
         )
         self.assertIsInstance(fs, HfFileSystem)
         self.assertEqual(fs._api.endpoint, ENDPOINT_STAGING)
-        self.assertEqual(fs.repo_id, self.repo_id)
         self.assertEqual(fs.token, TOKEN)
-        self.assertEqual(fs.repo_type, self.repo_type)
         self.assertEqual(fs.revision, "test-branch")
-        self.assertEqual(paths, ["data/text_data.txt"])
+        self.assertEqual(paths, [self.hf_path + "/data/text_data.txt"])
 
-        fs, _, _ = fsspec.get_fs_token_paths(f"hf://{self.repo_id}:/data/text_data.txt")
-        self.assertEqual(fs.repo_id, self.repo_id)
-        self.assertEqual(fs.repo_type, "model")
+        fs, _, paths = fsspec.get_fs_token_paths(f"hf://{self.repo_id}/data/text_data.txt")
+        self.assertIsInstance(fs, HfFileSystem)
+        self.assertEqual(paths, [f"{self.repo_id}/data/text_data.txt"])
 
 
+@pytest.mark.parametrize("path_in_repo", ["", "foo"])
 @pytest.mark.parametrize(
-    "path,expected",
+    "root_path,repo_type,repo_id",
     [
-        # Repo type "model" by default
-        ("gpt2", {"repo_id": "gpt2", "repo_type": "model"}),
-        ("hf://gpt2", {"repo_id": "gpt2", "repo_type": "model"}),
-        # Parse without protocol
-        ("datasets/username/my_dataset", {"repo_id": "username/my_dataset", "repo_type": "dataset"}),
+        # Parse without namespace
+        ("gpt2", None, "gpt2"),
+        ("datasets/squad", "dataset", "squad"),
+        # Parse with namespace
+        ("username/my_model", None, "username/my_model"),
+        ("datasets/username/my_dataset", "dataset", "username/my_dataset"),
         # Parse with hf:// protocol
-        ("hf://datasets/username/my_dataset", {"repo_id": "username/my_dataset", "repo_type": "dataset"}),
-        # Parse with revision
-        (
-            "hf://datasets/username/my_dataset@0123456789",
-            {"repo_id": "username/my_dataset", "repo_type": "dataset", "revision": "0123456789"},
-        ),
-        # Parse canonical models (no namespace)
-        ("gpt2", {"repo_id": "gpt2", "repo_type": "model"}),
-        ("hf://gpt2", {"repo_id": "gpt2", "repo_type": "model"}),
-        # Canonical datasets are not parsed correctly by huggingface_hub yet. They are processed separately by hffs.
-        ("datasets/squad", {"repo_id": "squad", "repo_type": "dataset"}),
-        ("hf://datasets/squad", {"repo_id": "squad", "repo_type": "dataset"}),
+        ("hf://gpt2", None, "gpt2"),
+        ("hf://datasets/squad", "dataset", "squad"),
     ],
 )
-def test_parse_hffs_path_success(path: str, expected: Dict[str, str]) -> None:
-    assert HfFileSystem._get_kwargs_from_urls(path) == expected
+def test_resolve_repo_id(root_path: str, repo_type: Optional[str], repo_id: str, path_in_repo: str) -> None:
+    fs = HfFileSystem()
+    path = root_path + "/" + path_in_repo if path_in_repo else root_path
+
+    def mock_repo_info(repo_id: str, *, repo_type: str, **kwargs):
+        if repo_id not in ["gpt2", "squad", "username/my_dataset", "username/my_model"]:
+            raise huggingface_hub.utils.RepositoryNotFoundError(repo_id)
+
+    with patch.object(fs._api, "repo_info", mock_repo_info):
+        assert fs._resolve_repo_id(path) == (repo_type, repo_id, path_in_repo)
+
+
+@pytest.mark.parametrize("not_supported_path", ["", "datasets", "hf://", "hf://datasets"])
+def test_list_repositories(not_supported_path):
+    fs = HfFileSystem()
+    with pytest.raises(NotImplementedError):
+        fs.ls(not_supported_path)

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -151,13 +151,13 @@ class HfFileSystemTests(unittest.TestCase):
     "root_path,repo_type,repo_id",
     [
         # Parse without namespace
-        ("gpt2", None, "gpt2"),
+        ("gpt2", "model", "gpt2"),
         ("datasets/squad", "dataset", "squad"),
         # Parse with namespace
-        ("username/my_model", None, "username/my_model"),
+        ("username/my_model", "model", "username/my_model"),
         ("datasets/username/my_dataset", "dataset", "username/my_dataset"),
         # Parse with hf:// protocol
-        ("hf://gpt2", None, "gpt2"),
+        ("hf://gpt2", "model", "gpt2"),
         ("hf://datasets/squad", "dataset", "squad"),
     ],
 )
@@ -173,8 +173,12 @@ def test_resolve_repo_id(root_path: str, repo_type: Optional[str], repo_id: str,
         assert fs._resolve_repo_id(path) == (repo_type, repo_id, path_in_repo)
 
 
-@pytest.mark.parametrize("not_supported_path", ["", "datasets", "hf://", "hf://datasets"])
-def test_list_repositories(not_supported_path):
+@pytest.mark.parametrize("not_supported_path", ["", "foo", "datasets", "datasets/foo"])
+def test_access_repositories_lists(not_supported_path):
     fs = HfFileSystem()
     with pytest.raises(NotImplementedError):
         fs.ls(not_supported_path)
+    with pytest.raises(NotImplementedError):
+        fs.glob(not_supported_path + "/")
+    with pytest.raises(NotImplementedError):
+        fs.open(not_supported_path)

--- a/ttest.py
+++ b/ttest.py
@@ -1,4 +1,0 @@
-from hffs import HfFileSystem
-
-fs = HfFileSystem()
-print(fs.glob("hf://**"))

--- a/ttest.py
+++ b/ttest.py
@@ -1,0 +1,4 @@
+from hffs import HfFileSystem
+
+fs = HfFileSystem()
+print(fs.glob("hf://**"))


### PR DESCRIPTION
Previously the root of a `HfFileSystem` was the root of the requested repository.

In this PR I set the root of the `HfFileSystem` to be the root of the Hugging Face Hub:

```python
>>> import hffs
>>> fs = hffs.HfFileSystem()
>>> fs.glob("my-username/my-model/*.bin")
["pytorch_model.bin"]
>>> fs.ls("datasets/my-username/my-dataset", detail=False)
['.gitattributes', 'README.md', 'data.json']
```

```python
>>> import fsspec
>>> with fsspec.open("hf://my-username/my-model/pytorch_model.bin") as f:
...     data = f.read()
```

### Implementation details:

To resolve the `repo_type`, `repo_id` and `path_in_repo`  in `hf://a/b/c/d` I proceed as follows:
1. get the `repo_type` depending on the value of `a`
2. get the `repo_id`:
    * it is `b/c` (or `a/b` for models) if the repository exists
    * otherwise it is `b` (or `a` for models) if the repository exists
3. get the `path_in_repo` which corresponds to the rest

Close https://github.com/huggingface/hffs/issues/17