### PR TITLE
More flexible revision control

### DIFF
--- a/src/hffs/__init__.py
+++ b/src/hffs/__init__.py
@@ -2,4 +2,4 @@
 
 __version__ = "0.0.1.dev0"
 
-from .fs import HfFileSystem
+from .fs import HfFileSystem, HfFile, ResolvedPath

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -119,7 +119,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         path = self._strip_protocol(path)
         if not path:
             # can't list repositories at root
-            raise NotImplementedError("Acces to repositories lists is not implemented.")
+            raise NotImplementedError("Access to repositories lists is not implemented.")
         elif path.split("/")[0] + "/" in huggingface_hub.constants.REPO_TYPES_URL_PREFIXES.values():
             if "/" not in path:
                 # can't list repositories at the repository type level

--- a/src/hffs/fs.py
+++ b/src/hffs/fs.py
@@ -206,7 +206,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
             repo_type=resolved_path.repo_type,
             token=self.token,
             operations=operations,
-            revision=revision,
+            revision=resolved_path.revision,
             commit_message=kwargs.get("commit_message", commit_message),
             commit_description=kwargs.get("commit_description"),
         )
@@ -217,7 +217,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
         root_path = (
             huggingface_hub.constants.REPO_TYPES_URL_PREFIXES.get(resolved_path.repo_type, "") + resolved_path.repo_id
         )
-        paths = self.expand_path(path, recursive=recursive, maxdepth=maxdepth, revision=revision)
+        paths = self.expand_path(path, recursive=recursive, maxdepth=maxdepth, revision=resolved_path.revision)
         paths_in_repo = [path[len(root_path) + 1 :] for path in paths if not self.isdir(path)]
         operations = [
             huggingface_hub.CommitOperationDelete(path_in_repo=path_in_repo) for path_in_repo in paths_in_repo
@@ -231,7 +231,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
             repo_type=resolved_path.repo_type,
             token=self.token,
             operations=operations,
-            revision=revision,
+            revision=resolved_path.revision,
             commit_message=kwargs.get("commit_message", commit_message),
             commit_description=kwargs.get("commit_description"),
         )
@@ -248,7 +248,7 @@ class HfFileSystem(fsspec.AbstractFileSystem):
                 ResolvedPath(resolved_path.repo_type, resolved_path.repo_id, resolved_path.revision, "").unresolve()
                 + "/"
             )
-            tree_iter = self._iter_tree(path, revision=revision)
+            tree_iter = self._iter_tree(path, revision=resolved_path.revision)
             try:
                 tree_item = next(tree_iter)
             except huggingface_hub.utils.EntryNotFoundError:

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -55,6 +55,15 @@ class HfFileSystemTests(unittest.TestCase):
             sorted([self.hf_path + "/.gitattributes", self.hf_path + "/data"]),
         )
 
+        self.assertEqual(
+            sorted(self.hffs.glob(self.hf_path + "/*", revision="main")),
+            sorted([self.hf_path + "/.gitattributes", self.hf_path + "/data"]),
+        )
+        self.assertEqual(
+            sorted(self.hffs.glob(self.hf_path + "@main" + "/*")),
+            sorted([self.hf_path + "@main" + "/.gitattributes", self.hf_path + "@main" + "/data"]),
+        )
+
     def test_file_type(self):
         self.assertTrue(
             self.hffs.isdir(self.hf_path + "/data") and not self.hffs.isdir(self.hf_path + "/.gitattributes")

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -150,19 +150,19 @@ class HfFileSystemTests(unittest.TestCase):
     [
         # Parse without namespace
         ("gpt2", "model", "gpt2", None),
-        ("gpt2/dev", "model", "gpt2", "dev"),
+        ("gpt2@dev", "model", "gpt2", "dev"),
         ("datasets/squad", "dataset", "squad", None),
-        ("datasets/squad/dev", "dataset", "squad", "dev"),
+        ("datasets/squad@dev", "dataset", "squad", "dev"),
         # Parse with namespace
         ("username/my_model", "model", "username/my_model", None),
-        ("username/my_model/dev", "model", "username/my_model", "dev"),
+        ("username/my_model@dev", "model", "username/my_model", "dev"),
         ("datasets/username/my_dataset", "dataset", "username/my_dataset", None),
-        ("datasets/username/my_dataset/dev", "dataset", "username/my_dataset", "dev"),
+        ("datasets/username/my_dataset@dev", "dataset", "username/my_dataset", "dev"),
         # Parse with hf:// protocol
         ("hf://gpt2", "model", "gpt2", None),
-        ("hf://gpt2/dev", "model", "gpt2", "dev"),
+        ("hf://gpt2@dev", "model", "gpt2", "dev"),
         ("hf://datasets/squad", "dataset", "squad", None),
-        ("hf://datasets/squad/dev", "dataset", "squad", "dev"),
+        ("hf://datasets/squad@dev", "dataset", "squad", "dev"),
     ],
 )
 def test_resolve_path(
@@ -171,11 +171,9 @@ def test_resolve_path(
     fs = HfFileSystem()
     path = root_path + "/" + path_in_repo if path_in_repo else root_path
 
-    def mock_repo_info(repo_id: str, *, repo_type: str, revision: str, **kwargs):
+    def mock_repo_info(repo_id: str, *, repo_type: str, **kwargs):
         if repo_id not in ["gpt2", "squad", "username/my_dataset", "username/my_model"]:
             raise huggingface_hub.utils.RepositoryNotFoundError(repo_id)
-        if revision not in ["main", "dev"]:
-            raise huggingface_hub.utils.RevisionNotFoundError(revision)
 
     with patch.object(fs._api, "repo_info", mock_repo_info):
         assert fs.resolve_path(path) == (repo_type, repo_id, revision, path_in_repo)


### PR DESCRIPTION
This PR aims to align the `revision` control with the new URL schema, which allows a single filesystem instance to interact with more than one Hub repo.

We have a couple of strategies to choose from to implement this:
* add `revision` as a parameter to the filesystem ops (pros: the simplest implementation and similar to the `HfApi` design; cons: some ops operate between two repos (e.g., `cp_file`), so we would need to introduce two `revision` params)
* add `revision` as a parameter to the filesystem ops + allow specifying `revision` in the path (pros: we can embed revisions into paths in `cp_file` instead of having two `revision` params + operation chaining if we embed revisions/branches into outputted paths (e.g., `fs.rm(fs.ls("datasets/repo/dev/data")[0]`); cons: implementation a bit more complex, also if we decide to embed revisions into returned paths it's not clear whether we should do this for all revisions or all revisions but the default one (`"main"`))

The current implementation follows the 2nd approach and embeds all revisions except the default one into returned paths, but now I think the 1st approach would be cleaner. Let me know which one of these two approaches you prefer.
